### PR TITLE
Fix bug in cache invalidation - hope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage.xml
-        if: ${{ matrix.python-version == '3.7' }} && (github.ref == 'refs/heads/master') }}
+        if: ${{ matrix.python-version == '3.7' && (github.ref == 'refs/heads/master') }}
       - name: Check style with black
         run: black --check --line-length 100 .
         if: ${{ matrix.python-version < '3.9' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -50,7 +50,7 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage.xml
-        if: ${{ matrix.python-version == '3.7' }}
+        if: ${{ matrix.python-version == '3.7' }} && (github.ref == 'refs/heads/master') }}
       - name: Check style with black
         run: black --check --line-length 100 .
         if: ${{ matrix.python-version < '3.9' }}

--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -817,8 +817,8 @@ class LinkInPathGenerator:
         for base_p in base_paths:
             dir_path = os.path.dirname(os.path.realpath(base_p))
             # Find all files
-            for _, _, files in os.walk(dir_path):
-                if sheet_file_name in files:
+            for item in os.listdir(dir_path):
+                if os.path.isfile(os.path.join(dir_path, item)) and sheet_file_name == item:
                     return os.path.join(dir_path, sheet_file_name)
         # If not found: None
         return None

--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -779,10 +779,44 @@ class LinkInPathGenerator:
         out_list = []
         # Iterate over DataSetInfo objects
         for info in data_set_infos:
-            out_list.append(getattr(info, "sheet_path"))  # expects a string
-            out_list.extend(getattr(info, "search_paths"))  # expects a list already
+
+            # Search paths - expects a list already
+            out_list.extend(getattr(info, "search_paths"))
+
+            # Sheet path
+            # Only name of file is stored in config file (relative path used),
+            # hence we need to find it in the base paths
+            sheet_file_name = getattr(info, "sheet_path")  # expects a string
+            base_paths = getattr(info, "base_paths")  # expects a list
+            sheet_path = cls._find_sheet_file(sheet_file_name, base_paths)
+            # Append if not None
+            if sheet_path:
+                out_list.append(sheet_path)
+
         # Return
         return out_list
+
+    @classmethod
+    def _find_sheet_file(cls, sheet_file_name, base_paths):
+        """Method searches for sheet file in base paths.
+
+        :param sheet_file_name: Sheet file name.
+        :type sheet_file_name: str
+
+        :param base_paths: List of strings with base paths.
+        :type base_paths: list
+
+        :return: Returns path to sheet file.
+        """
+        # Iterate over base paths
+        for base_p in base_paths:
+            dir_path = os.path.dirname(os.path.realpath(base_p))
+            # Find all files
+            for _, _, files in os.walk(dir_path):
+                if sheet_file_name in files:
+                    return os.path.join(dir_path, sheet_file_name)
+        # If not found: None
+        return None
 
 
 def get_ngs_library_folder_name(sheets, library_name):

--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -808,7 +808,12 @@ class LinkInPathGenerator:
 
         :return: Returns path to sheet file.
         """
+        # Check if full path already
+        if os.path.exists(sheet_file_name):
+            return sheet_file_name
         # Iterate over base paths
+        # Assumption: sheet file stored in the same level as config file,
+        # i.e., one of the base paths.
         for base_p in base_paths:
             dir_path = os.path.dirname(os.path.realpath(base_p))
             # Find all files

--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -815,10 +815,10 @@ class LinkInPathGenerator:
         # Assumption: sheet file stored in the same level as config file,
         # i.e., one of the base paths.
         for base_p in base_paths:
-            dir_path = os.path.dirname(os.path.realpath(base_p))
+            dir_path = os.path.realpath(base_p)
             # Find all files
             for item in os.listdir(dir_path):
-                if os.path.isfile(os.path.join(dir_path, item)) and sheet_file_name == item:
+                if sheet_file_name == item:
                     return os.path.join(dir_path, sheet_file_name)
         # If not found: None
         return None

--- a/tests/snappy_pipeline/workflows/conftest.py
+++ b/tests/snappy_pipeline/workflows/conftest.py
@@ -40,9 +40,16 @@ def work_dir():
 
 
 @pytest.fixture
-def config_lookup_paths():
-    """Return configuration lookup paths list for overall consistency in tests"""
-    return ["/decoy/config", "/work/config"]
+def config_lookup_paths(fake_fs):
+    """
+    :return: Returns configuration lookup paths list for overall consistency in tests.
+    Method also create paths in the fake file system.
+    """
+    lookup_paths = ["/decoy/config", "/work/config"]
+    for l_path in lookup_paths:
+        if not fake_fs.os.path.exists(l_path):
+            fake_fs.fs.create_dir(l_path)
+    return lookup_paths
 
 
 @pytest.fixture
@@ -151,7 +158,8 @@ def sample_cache_dict():
 def germline_sheet_fake_fs(fake_fs, germline_sheet_tsv):
     """Return fake file system setup with files for the germline_sheet_tsv"""
     # Create work directory
-    fake_fs.fs.create_dir("/work")
+    if not fake_fs.os.path.exists("/work"):
+        fake_fs.fs.create_dir("/work")
     # Create FASTQ read files for the samples
     tpl = "/path/{donor}/FCXXXXXX/L001/{donor}_R{i}.fastq.gz"
     for line in germline_sheet_tsv.splitlines()[1:]:
@@ -169,7 +177,8 @@ def germline_sheet_fake_fs(fake_fs, germline_sheet_tsv):
 def germline_sheet_fake_fs2(fake_fs2, germline_sheet_tsv):
     """Return fake file system setup with files for the germline_sheet_tsv"""
     # Create work directory
-    fake_fs2.fs.create_dir("/work")
+    if not fake_fs2.os.path.exists("/work"):
+        fake_fs2.fs.create_dir("/work")
     # Create FASTQ read files for the samples
     tpl = "/path/{donor}/{flowcell}/L001/{donor}_R{i}.fastq.gz"
     for line in germline_sheet_tsv.splitlines()[1:]:
@@ -188,7 +197,8 @@ def germline_sheet_fake_fs2(fake_fs2, germline_sheet_tsv):
 def cancer_sheet_fake_fs(fake_fs, cancer_sheet_tsv):
     """Return fake file system setup with files for the cancer_sheet_tsv"""
     # Create work directory
-    fake_fs.fs.create_dir("/work")
+    if not fake_fs.os.path.exists("/work"):
+        fake_fs.fs.create_dir("/work")
     # Create FASTQ read files for the samples
     tpl = "/path/{folder}/FCXXXXXX/L001/{folder}_R{i}.fastq.gz"
     for line in cancer_sheet_tsv.splitlines()[1:]:


### PR DESCRIPTION
closes #13 

**Summary**

- Fixed bug while defining path to sample sheet (e.g., `2021_<project_name>.tsv`) before invalidating cache. Tests were modified accordingly. 
- Modified CI workflow configuration.