### PR TITLE
Decrease project start verbose

### DIFF
--- a/snappy_pipeline/apps/impl/fsmanip.py
+++ b/snappy_pipeline/apps/impl/fsmanip.py
@@ -59,9 +59,7 @@ def create_directory(path, msg_lvl=LVL_INFO, exist_ok=False):
     os.makedirs(path, exist_ok=exist_ok)
 
 
-def create_from_tpl(
-    src_path, dest_path, format_args, message, message_args, msg_lvl=LVL_INFO, diff_context=3
-):
+def create_from_tpl(src_path, dest_path, format_args, message, message_args, msg_lvl=LVL_INFO):
     """Create file at ``dest_path`` from template at ``src_path``
 
     Put in format arguments from format_args (properly escape ``%``).
@@ -74,20 +72,6 @@ def create_from_tpl(
     with open(src_path, "rt") as f:
         contents = f.read()
     formatted = contents % format_args
-    # Create diff output and print
-    if msg_lvl:
-        diff = "".join(
-            difflib.unified_diff(
-                [],
-                formatted.splitlines(True),
-                "/dev/null",
-                dest_path,
-                file_mtime("/dev/null"),
-                datetime.datetime.now().isoformat(),
-                n=diff_context,
-            )
-        )
-    # log("applying the following change: \n\n{diff}", {"diff": diff}, level=LVL_INFO)
     with open(dest_path, "wt") as f:
         f.write(formatted)
 

--- a/snappy_pipeline/apps/impl/fsmanip.py
+++ b/snappy_pipeline/apps/impl/fsmanip.py
@@ -55,7 +55,7 @@ def create_directory(path, msg_lvl=LVL_INFO, exist_ok=False):
     Switch off messaging by setting msg_lvl to ``None``
     """
     if msg_lvl:
-        log("creating directory {path}", {"path": path}, level=msg_lvl)
+        log("Creating directory {path}", {"path": path}, level=msg_lvl)
     os.makedirs(path, exist_ok=exist_ok)
 
 
@@ -69,11 +69,10 @@ def create_from_tpl(
     Disable printing by setting ``msg_lvl`` to ``None``
     """
     if msg_lvl:
-        log("creating project-wide configuration in {path}", message_args, level=msg_lvl)
+        log(message, message_args, level=msg_lvl)
     # Read in the template and fill in values
     with open(src_path, "rt") as f:
         contents = f.read()
-    print("----\n%s\n----\n%s\n----\n" % (contents, format_args))
     formatted = contents % format_args
     # Create diff output and print
     if msg_lvl:
@@ -88,7 +87,7 @@ def create_from_tpl(
                 n=diff_context,
             )
         )
-    log("applying the following change: \n\n{diff}", {"diff": diff}, level=LVL_INFO)
+    # log("applying the following change: \n\n{diff}", {"diff": diff}, level=LVL_INFO)
     with open(dest_path, "wt") as f:
         f.write(formatted)
 

--- a/snappy_pipeline/apps/impl/fsmanip.py
+++ b/snappy_pipeline/apps/impl/fsmanip.py
@@ -131,6 +131,6 @@ def update_file(path, contents, message, message_args, msg_lvl=LVL_INFO, diff_co
                 n=diff_context,
             )
         )
-    log("applying the following change: \n\n{diff}", {"diff": diff}, level=LVL_INFO)
+    log("Applying the following change: \n\n{diff}", {"diff": diff}, level=LVL_INFO)
     with open(path, "wt") as f:
         f.write(contents)

--- a/snappy_pipeline/apps/snappy_start_project.py
+++ b/snappy_pipeline/apps/snappy_start_project.py
@@ -28,13 +28,16 @@ def run(args):
     log("================================")
     log("")
 
+    # Check if directory already exists - no overwrite
     if not assume_path_nonexisting(args.project_directory):
         return 1
 
+    # Create project directory and subdirectory for configuration files
     paths = (args.project_directory, os.path.join(args.project_directory, CONFIG_SUBDIR))
     for path in paths:
         create_directory(path)
 
+    # Create config file in subdirectory based on template
     create_from_tpl(
         src_path=os.path.join(os.path.dirname(__file__), "tpls", "project_config.yaml"),
         dest_path=os.path.join(args.project_directory, CONFIG_SUBDIR, CONFIG_FILENAME),
@@ -42,10 +45,11 @@ def run(args):
             "created_at": datetime.datetime.now().isoformat(),
             "project_name": (args.project_name or os.path.basename(args.project_directory)),
         },
-        message="creating project-wide configuration in {path}",
+        message="Creating project-wide configuration in {path}",
         message_args={"path": os.path.join(args.project_directory, CONFIG_SUBDIR, CONFIG_FILENAME)},
     )
 
+    # Create readme file in subdirectory based on template
     create_from_tpl(
         src_path=os.path.join(os.path.dirname(__file__), "tpls", README_FILENAME),
         dest_path=os.path.join(args.project_directory, README_FILENAME),
@@ -53,12 +57,13 @@ def run(args):
             "created_at": datetime.datetime.now().isoformat(),
             "project_name": (args.project_name or os.path.basename(args.project_directory)),
         },
-        message="creating README file in in {path}",
+        message="Creating README file in in {path}",
         message_args={"path": os.path.join(args.project_directory, README_FILENAME)},
     )
 
+    # Create additional steps if any was provided
     for step in args.steps:
-        run_start_step(step, step, args)
+        run_start_step(step=step, directory=step, args=args)
 
     log("\nDo not forget to fill out your README.md file!\n", level=LVL_IMPORTANT)
     log("all done, have a nice day!", level=LVL_SUCCESS)

--- a/snappy_pipeline/apps/snappy_start_project.py
+++ b/snappy_pipeline/apps/snappy_start_project.py
@@ -65,8 +65,11 @@ def run(args):
     for step in args.steps:
         run_start_step(step=step, directory=step, args=args)
 
-    log("\nDo not forget to fill out your README.md file!\n", level=LVL_IMPORTANT)
-    log("all done, have a nice day!", level=LVL_SUCCESS)
+    log(
+        "\nDo not forget to review .snappy_pipeline/config.yaml and to fill out README.md!\n",
+        level=LVL_IMPORTANT
+    )
+    log("All done, have a nice day!", level=LVL_SUCCESS)
 
 
 def main(argv=None):

--- a/snappy_pipeline/apps/snappy_start_project.py
+++ b/snappy_pipeline/apps/snappy_start_project.py
@@ -67,7 +67,7 @@ def run(args):
 
     log(
         "\nDo not forget to review .snappy_pipeline/config.yaml and to fill out README.md!\n",
-        level=LVL_IMPORTANT
+        level=LVL_IMPORTANT,
     )
     log("All done, have a nice day!", level=LVL_SUCCESS)
 

--- a/snappy_pipeline/apps/snappy_start_step.py
+++ b/snappy_pipeline/apps/snappy_start_step.py
@@ -57,7 +57,11 @@ class StartStepApp:
         log("")
         log(
             'Starting step "{step}" in sub-directory "{directory}" of project dir "{project_dir}"',
-            args={"step": self.step, "directory": self.directory, "project_dir": self.directory},
+            args={
+                "step": self.step,
+                "directory": self.directory,
+                "project_dir": self.args.project_directory,
+            },
         )
 
         dest_dir = os.path.join(self.args.project_directory, self.directory)
@@ -82,7 +86,7 @@ class StartStepApp:
             "\nDo not forget to fill out the required fields in the project configuration file!\n",
             level=LVL_IMPORTANT,
         )
-        log("all done, have a nice day!", level=LVL_SUCCESS)
+        log("Step {step} created. Done!", args={"step": self.step}, level=LVL_SUCCESS)
 
     def _load_config_yaml(self):
         """Load configuration."""
@@ -172,7 +176,20 @@ class StartStepApp:
 
 
 def run_start_step(step, directory, args):
-    """Run ``snappy-start-step``."""
+    """Run ``snappy-start-step``.
+
+    :param step: Name of step.
+    :type step: str
+
+    :param directory: Name of directory to store step configurations and results. Usually the same
+    name as the step.
+    :type directory: str
+
+    :param args: Arguments provided by the user.
+    :type args: argparse.Namespace
+
+    :return: Returns the return value of Start Step run call.
+    """
     return StartStepApp(step, directory, args).run()
 
 

--- a/snappy_pipeline/apps/snappy_start_step.py
+++ b/snappy_pipeline/apps/snappy_start_step.py
@@ -83,7 +83,7 @@ class StartStepApp:
             self._setup_configuration(config_yaml)
 
         log(
-            "\nDo not forget to fill out the required fields in the project configuration file!\n",
+            "\nDo not forget to fill out the REQUIRED fields in the project configuration file!\n",
             level=LVL_IMPORTANT,
         )
         log("Step {step} created. Done!", args={"step": self.step}, level=LVL_SUCCESS)

--- a/snappy_pipeline/apps/snappy_start_step.py
+++ b/snappy_pipeline/apps/snappy_start_step.py
@@ -86,7 +86,7 @@ class StartStepApp:
             "\nDo not forget to fill out the REQUIRED fields in the project configuration file!\n",
             level=LVL_IMPORTANT,
         )
-        log("Step {step} created. Done!", args={"step": self.step}, level=LVL_SUCCESS)
+        log("Step {step} created.", args={"step": self.step}, level=LVL_SUCCESS)
 
     def _load_config_yaml(self):
         """Load configuration."""

--- a/snappy_pipeline/apps/snappy_start_step.py
+++ b/snappy_pipeline/apps/snappy_start_step.py
@@ -123,7 +123,7 @@ class StartStepApp:
             src_path=os.path.join(os.path.dirname(__file__), "tpls", "step_config.yaml"),
             dest_path=os.path.join(dest_dir, CONFIG_FILENAME),
             format_args={"step_name": self.step, "step_version": 1, "config_subdir": CONFIG_SUBDIR},
-            message="creating step-wide configuration in {path}",
+            message="Creating step-wide configuration in {path}",
             message_args={"path": os.path.join(dest_dir, CONFIG_FILENAME)},
         )
 
@@ -143,7 +143,7 @@ class StartStepApp:
                 "conda": self.args.conda,
                 "step_name": self.step,
             },
-            message="creating SGE job shell file in {path}",
+            message="Creating SGE job shell file in {path}",
             message_args={"path": os.path.join(dest_dir, FILENAME_PIPELINE_JOB_SH)},
         )
 
@@ -170,7 +170,7 @@ class StartStepApp:
         update_file(
             path=config_filename,
             contents=updated_contents,
-            message="updating project config with required default config for step {step}",
+            message="Updating project config with required default config for step {step}",
             message_args={"step": self.step},
         )
 

--- a/snappy_pipeline/apps/tpls/project_config.yaml
+++ b/snappy_pipeline/apps/tpls/project_config.yaml
@@ -19,8 +19,8 @@ static_data_config:
 
 # Step Configuration ==============================================================================
 #
-# Configuration for the individual steps.  These can be filled by the cubi-start-step command
-# or initialized already with cubi-start-project.
+# Configuration for the individual steps.  These can be filled by the snappy-start-step command
+# or initialized already with snappy-start-project.
 #
 step_config: {}
 


### PR DESCRIPTION
closes #44 

**Changes**

Now outputting changes to file only when adding or updating steps in the config. Example:
```
$ snappy-start-project --directory somatic_project
SNAPPY Pipeline -- start_project
================================

INFO: Creating directory somatic_project
INFO: Creating directory somatic_project/.snappy_pipeline
INFO: Creating project-wide configuration in somatic_project/.snappy_pipeline/config.yaml
INFO: Creating README file in in somatic_project/README.md

Do not forget to review .snappy_pipeline/config.yaml and to fill out README.md!

SUCCESS: All done, have a nice day!
```