### PR TITLE
cubi conda url

### DIFF
--- a/snappy_wrappers/wrappers/eb_filter_par/environment.yaml
+++ b/snappy_wrappers/wrappers/eb_filter_par/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - ebfilter >=0.2.2
 - vcfpy

--- a/snappy_wrappers/wrappers/epitoper/environment.yaml
+++ b/snappy_wrappers/wrappers/epitoper/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda/
+- http://cubi-conda.bihealth.org/cubiconda/
 dependencies:
 - netmhccons ==1.1a
 - epitoper ==0.3

--- a/snappy_wrappers/wrappers/gatk_hc_gvcf/combine_gvcf/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_hc_gvcf/combine_gvcf/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.3.1

--- a/snappy_wrappers/wrappers/gatk_hc_gvcf/discovery/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_hc_gvcf/discovery/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.3.1

--- a/snappy_wrappers/wrappers/gatk_hc_gvcf/genotyping/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_hc_gvcf/genotyping/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.3.1

--- a/snappy_wrappers/wrappers/gatk_hc_gvcf_par/combine_gvcf/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_hc_gvcf_par/combine_gvcf/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.4

--- a/snappy_wrappers/wrappers/gatk_hc_gvcf_par/discovery/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_hc_gvcf_par/discovery/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.3.1

--- a/snappy_wrappers/wrappers/gatk_hc_gvcf_par/genotyping/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_hc_gvcf_par/genotyping/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.3.1

--- a/snappy_wrappers/wrappers/gatk_hc_par/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_hc_par/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools >=1.9

--- a/snappy_wrappers/wrappers/gatk_phase_by_transmission/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_phase_by_transmission/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - defaults
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.9

--- a/snappy_wrappers/wrappers/gatk_post_bam/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_post_bam/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - samtools ==1.3

--- a/snappy_wrappers/wrappers/gatk_read_backed_phasing/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_read_backed_phasing/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.9

--- a/snappy_wrappers/wrappers/gatk_read_backed_phasing_par/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_read_backed_phasing_par/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.9

--- a/snappy_wrappers/wrappers/gatk_ug_par/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_ug_par/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools >=1.9

--- a/snappy_wrappers/wrappers/melt/environment.yaml
+++ b/snappy_wrappers/wrappers/melt/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - melt_mei
 - htslib

--- a/snappy_wrappers/wrappers/minialign/run/environment.yaml
+++ b/snappy_wrappers/wrappers/minialign/run/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - minialign ==0.5.3
 - samtools ==1.9

--- a/snappy_wrappers/wrappers/mutect/environment.yaml
+++ b/snappy_wrappers/wrappers/mutect/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - mutect_nonfree ==1.1.7
 - htslib >=1.9

--- a/snappy_wrappers/wrappers/mutect2/environment.yaml
+++ b/snappy_wrappers/wrappers/mutect2/environment.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk4
 - htslib ==1.9

--- a/snappy_wrappers/wrappers/xhmm/environment_gatk.yaml
+++ b/snappy_wrappers/wrappers/xhmm/environment_gatk.yaml
@@ -2,7 +2,7 @@ channels:
 - conda-forge
 - bioconda
 - r
-- http://cubiconda.bihealth.org/cubiconda
+- http://cubi-conda.bihealth.org/cubiconda
 dependencies:
 - gatk_nonfree ==3.7
 - bcftools ==1.3.1


### PR DESCRIPTION
closes #68 

**Changes**
- Updated CUBI conda url to: cubi-conda.bihealth.org