### PR TITLE
snappy-snake name change

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -112,7 +112,7 @@ The following figure shows the different components that are involved for runnin
 
 The different parts are as follows
 
-- The blue-colored boxes represent the ``snappy_pipeline`` Python package that contains the ``cubi-snake`` executable and the code for the different pipeline steps.
+- The blue-colored boxes represent the ``snappy_pipeline`` Python package that contains the ``snappy-snake`` executable and the code for the different pipeline steps.
 
 - The yellow-colored boxes represent the project directory with the different sub directories for the step instances.
   For each step that is to be executed (with a given configuration set), a directory is created.
@@ -195,7 +195,7 @@ The project directory is setup with the following helper tool:
 
 ::
 
-    $ cubi-start-project --directory somatic_project
+    $ snappy-start-project --directory somatic_project
     [...]
     Do not forget to fill out your README.md file!
 
@@ -231,7 +231,7 @@ Further, a project-wide ``README.md`` file is setup in which you can place docum
 Working Directories for Step Instances
 ======================================
 
-Next, we create the different step instances that we want to use using ``cubi-start-step``.
+Next, we create the different step instances that we want to use using ``snappy-start-step``.
 Note that this will extend the ``.snappy_pipeline/config.yaml`` file if there is no configuration entry for the given step.
 A different name for the instance can be given using the ``--step`` parameter.
 
@@ -244,15 +244,15 @@ For all configuration settings that have no default and are marked with a ``# re
 ::
 
     $ cd somatic_project
-    $ cubi-start-step --step ngs_mapping
+    $ snappy-start-step --step ngs_mapping
     [...]
     INFO: applying the following change:
 
     --- a/.snappy_pipeline/config.yaml	2017-02-03T12:47:32.246833
     +++ b/.snappy_pipeline/config.yaml	2017-02-03T12:49:29.811706
     @@ -22,7 +22,12 @@
-     # Configuration for the individual steps.  These can be filled by the cubi-start-step command
-     # or initialized already with cubi-start-project.
+     # Configuration for the individual steps.  These can be filled by the snappy-start-step command
+     # or initialized already with snappy-start-project.
      #
     -step_config: {}
     +step_config:
@@ -283,7 +283,7 @@ Similarly, adding ``somatic_variant_calling`` adds configuration for somatic var
 
 ::
 
-    $ cubi-start-step --step somatic_variant_calling
+    $ snappy-start-step --step somatic_variant_calling
     [...]
     INFO: applying the following change:
 
@@ -311,7 +311,7 @@ The same is true for adding ``somatic_variant_annotation``.
 
 ::
 
-    $ cubi-start-step --step somatic_variant_annotation
+    $ snappy-start-step --step somatic_variant_annotation
     [...]
     INFO: applying the following change:
 
@@ -419,11 +419,11 @@ For running, locally use:
 .. code-block:: shell
 
     $ cd somatic_variant_annotation
-    $ cubi-snake -p --step somatic_variant_annotation
+    $ snappy-snake -p --step somatic_variant_annotation
 
-For running with SGE on the cluster, use the ``--cubi-pipeline-drmaa`` parameter.
+For running with SGE on the cluster, use the ``--snappy-pipeline-use-drmaa`` parameter.
 
 .. code-block:: shell
 
     $ cd somatic_variant_annotation
-    $ cubi-snake -p --step somatic_variant_annotation --cubi-pipeline-drmaa
+    $ snappy-snake -p --step somatic_variant_annotation --snappy-pipeline-use-drmaa

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -92,13 +92,15 @@ Replace the `X.Y.Z` in the definition of ``VERSION`` below with the version you 
     $ VERSION=vX.Y.Z
     $ pip install git+ssh://git@gitlab.bihealth.org/cubi/snappy_pipeline.git@v${VERSION}#egg=snappy_pipeline
 
-Execute ``cubi-snake --cubi-pipeline-self-test`` to see the current setup.
+Or see ``README.rst`` for a more detailed intallation guide and the environment setup step.
+
+Execute ``snappy-snake --snappy-pipeline-self-test`` to see the current setup.
 Make sure that the configuration shows that DRMAA is enabled.
 
 .. code-block:: shell
     :emphasize-lines: 10
 
-    $ cubi-snake --cubi-pipeline-self-test
+    $ snappy-snake --snappy-pipeline-self-test
     CUBI Pipeline
     =============
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,7 +4,7 @@
 Usage
 =====
 
-As a user, you will mostly interface with the CUBI pipeline system using the ``cubi-snake`` program.
+As a user, you will mostly interface with the CUBI pipeline system using the ``snappy-snake`` program.
 
 This program is a wrapper around `Snakemake <https://snakemake.bitbucket.org>`_ and provides the following features:
 
@@ -18,10 +18,10 @@ Here is how to get command line help:
 
 .. code-block:: shell
 
-    $ cubi-snake --help
+    $ snappy-snake --help
 
 Here is how to print the version and enabled features:
 
 .. code-block:: shell
 
-    $ cubi-snake --cubi-pipeline-self-test
+    $ snappy-snake --snappy-pipeline-self-test


### PR DESCRIPTION
Updated name change from cubi-snake to snappy-snake.
Added reference to README file, since no version of the pipeline is available while pip installing the file.