### PR TITLE
Link in MD5 rawdata files

### DIFF
--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -788,7 +788,7 @@ class LinkInPathGenerator:
             os.path.join(self.work_dir, self.cache_file_name), invalidate_paths_list
         )
 
-    def run(self, folder_name, pattern_set_keys=("left", "right", "bam")):
+    def run(self, folder_name, pattern_set_keys=("left", "right", "left_md5", "right_md5", "bam")):
         """Yield (src_path, path_infix, filename) one-by-one
 
         Cache is saved after the last iteration
@@ -803,7 +803,13 @@ class LinkInPathGenerator:
             for pat in info.search_patterns:
                 if not isinstance(pat, (dict, MutableMapping)):
                     raise ValueError("search_patterns must be a dict!")  # pragma: no cover
+                # Add patterns as found in configuration file: DataSetInfo.search_patterns
                 patterns.append(PatternSet(pat.values(), names=pat.keys()))
+                # Add MD5 files to search file as default
+                pat_md5 = [pattern + ".md5" for pattern in pat.values()]
+                pat_names_md5 = [pattern + "_md5" for pattern in pat.keys()]
+                patterns.append(PatternSet(pat_md5, names=pat_names_md5))
+
             # Crawl all root paths, link in the resulting files
             for root_path in self._get_shell_cmd_root_paths(info):
                 if root_path in seen_root_paths:

--- a/tests/snappy_pipeline/workflows/conftest.py
+++ b/tests/snappy_pipeline/workflows/conftest.py
@@ -226,8 +226,14 @@ def germline_sheet_fake_fs(fake_fs, germline_sheet_tsv):
     tpl = "/path/{donor}/FCXXXXXX/L001/{donor}_R{i}.fastq.gz"
     for line in germline_sheet_tsv.splitlines()[1:]:
         donor = line.split("\t")[0]
+        # Create fastq files
         fake_fs.fs.create_file(tpl.format(donor=donor, i=1))
         fake_fs.fs.create_file(tpl.format(donor=donor, i=2))
+        # Create md5 files
+        md5_r1 = tpl.format(donor=donor, i=1) + ".md5"
+        fake_fs.fs.create_file(md5_r1)
+        md5_r2 = tpl.format(donor=donor, i=2) + ".md5"
+        fake_fs.fs.create_file(md5_r2)
     # Create the sample TSV file
     fake_fs.fs.create_file(
         "/work/config/sheet.tsv", contents=germline_sheet_tsv, create_missing_dirs=True

--- a/tests/snappy_pipeline/workflows/test_workflows_abstract.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_abstract.py
@@ -117,6 +117,8 @@ def test_link_in_path_generator(germline_sheet_fake_fs, config_lookup_paths, wor
     expected = [
         ("/path/P001/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R1.fastq.gz"),
         ("/path/P001/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R2.fastq.gz"),
+        ("/path/P001/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R1.fastq.gz.md5"),
+        ("/path/P001/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R2.fastq.gz.md5"),
     ]
     assert list(generator.run("P001")) == expected
 
@@ -216,6 +218,8 @@ def test_link_in_step_part_get_shell_cmd(
         r"""
         mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz || ln -sr /path/P001/FCXXXXXX/L001/P001_R1.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
         mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz || ln -sr /path/P001/FCXXXXXX/L001/P001_R2.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz.md5 || ln -sr /path/P001/FCXXXXXX/L001/P001_R1.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz.md5 || ln -sr /path/P001/FCXXXXXX/L001/P001_R2.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
         """
     ).strip()
     assert actual == expected


### PR DESCRIPTION
closes #79 

**Changes**
* Create symbolic link (i.e., 'link in') md5 files associated with fastq files as default behaviour.