### PR TITLE
Adjust XHMM merge cov rule

### DIFF
--- a/snappy_wrappers/wrappers/xhmm/merge_cov/wrapper.py
+++ b/snappy_wrappers/wrappers/xhmm/merge_cov/wrapper.py
@@ -1,7 +1,19 @@
 # -*- coding: utf-8 -*-
 # Merge the coverage tracks created in the "gatk_cov" steps.
 
+import os
+
 from snakemake.shell import shell
+
+# Create file with GATK sample_interval_summary output files
+# used in `--GATKdepthsList`
+work_dir = os.getcwd()
+list_path = os.path.join(os.path.dirname(str(snakemake.output)), "gatk_depths.list")
+with open(list_path, "w") as f:
+    for item in snakemake.input:
+        full_path = os.path.join(work_dir, item)
+        f.write("%s\n" % full_path)
+
 
 shell(
     r"""
@@ -10,6 +22,6 @@ set -x
 xhmm \
     --mergeGATKdepths \
     -o {snakemake.output} \
-    $(for p in {snakemake.input}; do echo --GATKdepths $p; done)
+    --GATKdepthsList {list_path}
 """
 )


### PR DESCRIPTION
closes #86 

**Change**
Adjust XHMM merge cov rule to use depth list file instead of individual files as argument.

**Test**
Tested with a subset of NAMSE (11 samples). No difference between `master` and `86-fix-xhmm-argument` for file `bwa.xhmm_merge_cov.Agilent_SureSelect_Human_All_Exon_V6.RD.txt`.