### PR TITLE
Adjust dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10"
+          # - "3.10"  # `pysam` is incompatible with python v3.10
 
     steps:
       - name: Install Python via conda.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
-#         - 3.9  # no pysam binaries yet
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - name: Install Python via conda.

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 channels:
+  - conda-forge
   - bioconda
   - defaults
-  - conda-forge
 
 name: snappy_env
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - git-lfs
 
   # Snakemake is used for providing the actual wrapper calling functionality
-  - snakemake
+  - snakemake >=7.0.2
 
   # Additional libraries used by snappy
   - ruamel.yaml             # Nice, round-trip enabled YAML parsing

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ biomedsheets >=0.11.1
 termcolor==1.1.0
 
 # Snakemake is used for providing the actual wrapper calling functionality
-snakemake
+snakemake >=7.0.2
 # Snakemake needs manual install of PyYAML to make YAML configuration loading work
 PyYAML>=3.12
 

--- a/setup.py
+++ b/setup.py
@@ -127,9 +127,11 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+
     ],
     test_suite="tests",
     tests_require=test_requirements,

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ def parse_requirements(path):
     return requirements
 
 
-# Enforce python version >=3.4
-if sys.version_info < (3, 4):
-    print("At least Python 3.4 is required.\n", file=sys.stderr)
+# Enforce python version >=3.7
+if sys.version_info < (3, 7):
+    print("At least Python 3.7 is required.\n", file=sys.stderr)
     sys.exit(1)
 
 with open("README.rst") as readme_file:
@@ -130,8 +130,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-
     ],
     test_suite="tests",
     tests_require=test_requirements,

--- a/snappy_wrappers/wrappers/varfish_annotator/environment.yaml
+++ b/snappy_wrappers/wrappers/varfish_annotator/environment.yaml
@@ -4,5 +4,5 @@ channels:
 dependencies:
   - bcftools >=1.9
   - htslib >=1.9
-  - varfish-annotator-cli ==0.13
+  - varfish-annotator-cli ==0.21
   - jq


### PR DESCRIPTION
closes #130, closes #132

**Changes**
* Updated `varfish-annotator-cli` to latest version in wrapper environment, v0.21.
* Drop support for Python v3.6, add support for v3.9.
* Changed channel priority during mamba package installation. Source: https://github.com/bioconda/bioconda-recipes/issues/34190

_Note:_ On the user level it required the following change to `.condarc`
```
$ cat .condarc
channel_priority: strict
channels:
  - conda-forge
  - bioconda
  - defaults
```