### PR TITLE
Fix freebayes wrapper

### DIFF
--- a/snappy_wrappers/wrappers/freebayes/environment.yaml
+++ b/snappy_wrappers/wrappers/freebayes/environment.yaml
@@ -1,5 +1,6 @@
 channels:
-- bioconda
+  - conda-forge
+  - bioconda
 
 dependencies:
 - python

--- a/snappy_wrappers/wrappers/freebayes/wrapper.py
+++ b/snappy_wrappers/wrappers/freebayes/wrapper.py
@@ -61,6 +61,9 @@ fi
 # Export library
 export LD_LIBRARY_PATH=$(dirname $(which bgzip))/../lib
 
+# Hack: get back bin directory of base/root environment
+export PATH=$PATH:$(dirname $(dirname $(which conda)))/bin
+
 export TMPDIR=$(mktemp -d)
 trap "rm -rf $TMPDIR" EXIT
 


### PR DESCRIPTION
closes #135 

**Changes**
* Reintroduced conda-forge to env channels.
* Reintroduced hack to make `snappy-vcf_sort` available from wrapper env.

**Tests**
Tested using WES data for NA12878.