### PR TITLE
variant-annotator wrapper gets genome release from config

### DIFF
--- a/snappy_pipeline/workflows/variant_export/__init__.py
+++ b/snappy_pipeline/workflows/variant_export/__init__.py
@@ -82,6 +82,7 @@ step_config:
     path_variant_calling: ../variant_calling
     tools_ngs_mapping: null
     tools_variant_calling: null
+    release: GRCh37              # REQUIRED: default 'GRCh37'
     path_exon_bed: REQUIRED      # REQUIRED: exon BED file to use when handling WGS data
     path_refseq_ser: REQUIRED    # REQUIRED: path to RefSeq .ser file
     path_ensembl_ser: REQUIRED   # REQUIRED: path to ENSEMBL .ser file

--- a/snappy_wrappers/wrappers/varfish_annotator/annotate/wrapper.py
+++ b/snappy_wrappers/wrappers/varfish_annotator/annotate/wrapper.py
@@ -16,7 +16,6 @@ this_file = __file__
 annotation_args = []
 
 # TODO: care about case of WGS data
-# TODO: properly handle release
 # TODO: remove case ID parameter from annotator
 
 shell(
@@ -81,7 +80,7 @@ varfish-annotator \
     -XX:MaxHeapSize=10g \
     -XX:+UseConcMarkSweepGC \
     \
-    --release GRCh37 \
+    --release {export_config[release]} \
     \
     --ref-path {snakemake.config[static_data_config][reference][path]} \
     --db-path {export_config[path_db]} \


### PR DESCRIPTION
closes #113 

**Changes**
* Removed hardcoded genome release from `varfish_annotator/annotate`, get it from config instead.

**Tests**
For 11 samples from the NAMSE cohort compared the output from `master` vs. `113-variant-annotator-genome-release` branches (extensions: `.gts.tsv.gz`,  `db-infos.tsv.gz`, and `bam-qc.tsv.gz`). The outputted files are exactly the same.
