### PR TITLE
Replace deprecated Java VM garbage collector option

### DIFF
--- a/snappy_wrappers/wrappers/jannovar/annotate_somatic_vcf/wrapper.py
+++ b/snappy_wrappers/wrappers/jannovar/annotate_somatic_vcf/wrapper.py
@@ -110,7 +110,7 @@ jannovar \
     annotate-vcf \
     -XX:MaxHeapSize=5g \
     -XX:CompressedClassSpaceSize=512m \
-    -XX:+UseConcMarkSweepGC \
+    -XX:+UseG1GC \
     --input-vcf {snakemake.input.vcf} \
     --output-vcf {snakemake.output.vcf} \
     --database {snakemake.config[step_config][somatic_variant_annotation][path_jannovar_ser]} \

--- a/snappy_wrappers/wrappers/jannovar/annotate_vcf/wrapper.py
+++ b/snappy_wrappers/wrappers/jannovar/annotate_vcf/wrapper.py
@@ -109,7 +109,7 @@ MALLOC_ARENA_MAX=4 \
 jannovar \
     annotate-vcf \
     -XX:MaxHeapSize=12g \
-    -XX:+UseConcMarkSweepGC \
+    -XX:+UseG1GC \
     --input-vcf {snakemake.input.vcf} \
     --output-vcf $TMPDIR/tmp.vcf \
     --database {snakemake.config[step_config][variant_annotation][path_jannovar_ser]} \

--- a/snappy_wrappers/wrappers/varfish_annotator/annotate/wrapper.py
+++ b/snappy_wrappers/wrappers/varfish_annotator/annotate/wrapper.py
@@ -78,7 +78,7 @@ MALLOC_ARENA_MAX=4 \
 varfish-annotator \
     annotate \
     -XX:MaxHeapSize=10g \
-    -XX:+UseConcMarkSweepGC \
+    -XX:+UseG1GC \
     \
     --release {export_config[release]} \
     \

--- a/snappy_wrappers/wrappers/varfish_annotator/annotate_sv/wrapper.py
+++ b/snappy_wrappers/wrappers/varfish_annotator/annotate_sv/wrapper.py
@@ -87,7 +87,7 @@ MALLOC_ARENA_MAX=4 \
 varfish-annotator \
     annotate-svs \
     -XX:MaxHeapSize=10g \
-    -XX:+UseConcMarkSweepGC \
+    -XX:+UseG1GC \
     \
     --release GRCh37 \
     \


### PR DESCRIPTION
closes #182 

**Changes**
* Replaced Java VM garbage collection option: Concurrent Mark Sweep (CMS) -> G1 garbage collector

**Tests**
Cancer WES (e2e)