### PR TITLE
Fixed log path provided to step `prepare` from tool CopyWriter

### DIFF
--- a/snappy_pipeline/workflows/somatic_targeted_seq_cnv_calling/Snakefile
+++ b/snappy_pipeline/workflows/somatic_targeted_seq_cnv_calling/Snakefile
@@ -73,7 +73,7 @@ rule somatic_targeted_seq_cnv_calling_copywriter_prepare:
         memory=wf.get_resource("copywriter", "prepare", "memory"),
         partition=wf.get_resource("copywriter", "prepare", "partition"),
     log:
-        wf.get_log_file("copywriter", "prepare"),
+        **wf. get_log_file("copywriter","prepare"),
     wrapper:
         wf.wrapper_path("copywriter/prepare")
 

--- a/snappy_pipeline/workflows/somatic_targeted_seq_cnv_calling/__init__.py
+++ b/snappy_pipeline/workflows/somatic_targeted_seq_cnv_calling/__init__.py
@@ -844,9 +844,9 @@ class CopywriterStepPart(SomaticTargetedSeqCnvCallingStepPart):
         )
 
         if action == "prepare":
-            # TODO: Possible bug. It should still yield dict-like format, no?
-            tpl = "work/copywriter.{action}/log/snakemake.log"
-            return tpl.format(action=action)
+            log_file = "work/copywriter.prepare/log/snakemake.log"
+            yield "log", log_file
+            yield "log_md5", log_file + ".md5"
         elif action in ("call", "run"):
             tpl = (
                 "work/{mapper}.copywriter.{library_name}/log/{mapper}.copywriter.{library_name}."

--- a/snappy_wrappers/wrappers/copywriter/prepare/wrapper.py
+++ b/snappy_wrappers/wrappers/copywriter/prepare/wrapper.py
@@ -15,13 +15,13 @@ export TMPDIR=$(mktemp -d)
 trap "rm -rf $TMPDIR" EXIT
 
 # Also pipe stderr to log file
-if [[ -n "{snakemake.log}" ]]; then
+if [[ -n "{snakemake.log.log}" ]]; then
     if [[ "$(set +e; tty; set -e)" != "" ]]; then
-        rm -f "{snakemake.log}" && mkdir -p $(dirname {snakemake.log})
-        exec 2> >(tee -a "{snakemake.log}" >&2)
+        rm -f "{snakemake.log.log}" && mkdir -p $(dirname {snakemake.log.log})
+        exec 2> >(tee -a "{snakemake.log.log}" >&2)
     else
-        rm -f "{snakemake.log}" && mkdir -p $(dirname {snakemake.log})
-        echo "No tty, logging disabled" >"{snakemake.log}"
+        rm -f "{snakemake.log.log}" && mkdir -p $(dirname {snakemake.log.log})
+        echo "No tty, logging disabled" >"{snakemake.log.log}"
     fi
 fi
 
@@ -51,12 +51,15 @@ popd
 mv $TMPDIR/*/GC_mappability.rda {snakemake.output.gc}
 mv $TMPDIR/*/blacklist.rda {snakemake.output.blacklist}
 
-# md5 sums
+# md5 sums output
 out_dir=$(readlink -f $(dirname {snakemake.output.gc}))
 pushd $out_dir && \
     for i in *.rda; do
         md5sum $i > ${{i}}.md5
     done
     popd
+
+# md5 sum log
+md5sum {snakemake.log.log} > {snakemake.log.log_md5}
 """
 )

--- a/tests/snappy_pipeline/workflows/test_workflows_somatic_targeted_seq_cnv_calling.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_somatic_targeted_seq_cnv_calling.py
@@ -870,11 +870,10 @@ def test_copywriter_step_part_get_output_files_call(somatic_targeted_seq_cnv_cal
 
 def test_copywriter_step_part_get_log_file_prepare(somatic_targeted_seq_cnv_calling_workflow):
     """Tests CopywriterStepPart.get_log_file() - action 'prepare'"""
-    # TODO: Possible bug, I would expect it return something like the dict below.
-    #  {
-    #  "log": "work/copywriter.prepare/log/snakemake.log"
-    #  }
-    expected = {}
+    expected = {
+        "log": "work/copywriter.prepare/log/snakemake.log",
+        "log_md5": "work/copywriter.prepare/log/snakemake.log.md5",
+    }
     actual = somatic_targeted_seq_cnv_calling_workflow.get_log_file("copywriter", "prepare")
     assert actual == expected
 


### PR DESCRIPTION
fixes #128 