### PR TITLE
Fixed log files path definitions for `GatkPostBamStepPart`

### DIFF
--- a/snappy_pipeline/workflows/ngs_mapping/__init__.py
+++ b/snappy_pipeline/workflows/ngs_mapping/__init__.py
@@ -823,10 +823,18 @@ class GatkPostBamStepPart(BaseStepPart):
                     infix=recalibrated_infix, ext=ext
                 )
 
-    @staticmethod
-    def get_log_file(action):
+    @dictify
+    def get_log_file(self, action):
         _ = action
-        return "work/{mapper}.{library_name}/log/snakemake.gatk_post_bam.log"
+        prefix = "work/{mapper}.{library_name}/log/gatk_pos_bam.{library_name}"
+        key_ext = (
+            ("log", ".log"),
+            ("conda_info", ".conda_info.txt"),
+            ("conda_list", ".conda_list.txt"),
+        )
+        for key, ext in key_ext:
+            yield key, prefix + ext
+            yield key + "_md5", prefix + ext + ".md5"
 
     def get_resource_usage(self, action):
         """Get Resource Usage
@@ -843,9 +851,9 @@ class GatkPostBamStepPart(BaseStepPart):
             error_message = f"Action '{action}' is not supported. Valid options: {actions_str}"
             raise UnsupportedActionException(error_message)
         return ResourceUsage(
-            threads=16,
+            threads=2,
             time="2-00:00:00",  # 2 days
-            memory="16G",
+            memory="52G",
         )
 
 

--- a/snappy_pipeline/workflows/ngs_mapping/__init__.py
+++ b/snappy_pipeline/workflows/ngs_mapping/__init__.py
@@ -826,7 +826,7 @@ class GatkPostBamStepPart(BaseStepPart):
     @dictify
     def get_log_file(self, action):
         _ = action
-        prefix = "work/{mapper}.{library_name}/log/gatk_pos_bam.{library_name}"
+        prefix = "work/{mapper}.{library_name}/log/gatk_post_bam.{library_name}"
         key_ext = (
             ("log", ".log"),
             ("conda_info", ".conda_info.txt"),

--- a/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping.py
@@ -551,15 +551,9 @@ def test_gatk_post_bam_step_part_get_output_files(ngs_mapping_workflow):
 
 def test_gatk_post_bam_step_part_get_log_file(ngs_mapping_workflow):
     """Tests GatkPostBamStepPart.get_log_file()"""
-    base_name_out = "work/{mapper}.{library_name}/log/gatk_post_bam.{library_name}"
-    expected = {
-        "log": base_name_out + ".log",
-        "log_md5": base_name_out + ".log.md5",
-        "conda_info": base_name_out + ".conda_info.txt",
-        "conda_info_md5": base_name_out + ".conda_info.txt.md5",
-        "conda_list": base_name_out + ".conda_list.txt",
-        "conda_list_md5": base_name_out + ".conda_list.txt.md5",
-    }
+    expected = get_expected_log_files_dict(
+        base_out="work/{mapper}.{library_name}/log/gatk_post_bam.{library_name}"
+    )
     actual = ngs_mapping_workflow.get_log_file("gatk_post_bam", "run")
     assert actual == expected
 

--- a/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping.py
@@ -551,7 +551,15 @@ def test_gatk_post_bam_step_part_get_output_files(ngs_mapping_workflow):
 
 def test_gatk_post_bam_step_part_get_log_file(ngs_mapping_workflow):
     """Tests GatkPostBamStepPart.get_log_file()"""
-    expected = "work/{mapper}.{library_name}/log/snakemake.gatk_post_bam.log"
+    base_name_out = "work/{mapper}.{library_name}/log/gatk_post_bam.{library_name}"
+    expected = {
+        "log": base_name_out + ".log",
+        "log_md5": base_name_out + ".log.md5",
+        "conda_info": base_name_out + ".conda_info.txt",
+        "conda_info_md5": base_name_out + ".conda_info.txt.md5",
+        "conda_list": base_name_out + ".conda_list.txt",
+        "conda_list_md5": base_name_out + ".conda_list.txt.md5",
+    }
     actual = ngs_mapping_workflow.get_log_file("gatk_post_bam", "run")
     assert actual == expected
 
@@ -559,7 +567,7 @@ def test_gatk_post_bam_step_part_get_log_file(ngs_mapping_workflow):
 def test_gatk_post_bam_step_part_get_resource(ngs_mapping_workflow):
     """Tests GatkPostBamStepPart.get_resource()"""
     # Define expected
-    expected_dict = {"threads": 16, "time": "2-00:00:00", "memory": "16G", "partition": "medium"}
+    expected_dict = {"threads": 2, "time": "2-00:00:00", "memory": "52G", "partition": "medium"}
     # Evaluate
     for resource, expected in expected_dict.items():
         msg_error = f"Assertion error for resource '{resource}'."


### PR DESCRIPTION
Small bug in the generation of log file names: the conda log files are required by the wrapper, but not created by the pipeline.