### PR TITLE
Add adapter trimming workflow (214)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Project Info
 
     step_intro
     step_generic
+    step/adapter_trimming
     step/helper_gcnv_model
     step/hla_typing
     step/igv_session_generation

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -156,6 +156,26 @@ The different parts are as follows:
 - The static data files setup by the Cubit administrator (here, it would be the reference FASTA path and the read mapper index location).
 - The raw data files to be processed by the pipeline step (here, it would be the sample FASTQ files).
 
+How FASTQ files are found
+=========================
+
+In its ``data_sets`` section, the project-level configuration file provides search paths and search patterns to find the input FASTQ files. ``snappy`` internally combines these paths & search patterns with the sample-specific path information provided in the sample sheet. In the end, FASTQ files retained for processing are files which paths match:
+
+::
+
+    <configuration search path>/<sample-specific folder>/../<search pattern>
+
+The search will loop over provided search paths & search patterns. Paired reads files are coupled by similarity of their path. Note that when the ``Folder`` entry is absent from the sample sheet, the library name is used instead.
+
+However, this default behaviour can be overriden using the ``path_link_in`` option (which is available only for steps that use FASTQ files as input). When this configuration option is not empty, ``snappy`` will use it instead of the list of search paths defined in the ``data_set`` part. It will also ignore the folder information, and rely instead on the library names to search FASTQ files. The search path becomes:
+
+::
+
+    <path_link_in>/<library_name>/../<search_pattern>
+
+This mechanism enables steps that generate FASTQ files on output, for example adapter trimming. In that case, the input of the mapping step can be redirected towards the ouput of the adapter trimming step using this method.
+
+
 Overview of the Somatic Variant Pipeline
 ========================================
 

--- a/docs/step/adapter_trimming.rst
+++ b/docs/step/adapter_trimming.rst
@@ -1,0 +1,7 @@
+.. _step_adapter_trimming:
+
+================
+Adapter Trimming
+================
+
+.. automodule:: snappy_pipeline.workflows.adapter_trimming

--- a/snappy_pipeline/apps/snappy_snake.py
+++ b/snappy_pipeline/apps/snappy_snake.py
@@ -18,6 +18,7 @@ from snakemake import main as snakemake_main
 
 from .. import __version__
 from ..workflows import (
+    adapter_trimming,
     cbioportal_export,
     gene_expression_quantification,
     gene_expression_report,
@@ -81,6 +82,7 @@ SHELL = "/bin/bash"
 
 #: Mapping from step name to module
 STEP_TO_MODULE = {
+    "adapter_trimming": adapter_trimming,
     "gene_expression_quantification": gene_expression_quantification,
     "gene_expression_report": gene_expression_report,
     "cbioportal_export": cbioportal_export,

--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -1027,6 +1027,8 @@ class LinkInStep(BaseStepPart):
         out_path = os.path.dirname(self.base_pattern_out.format(**wildcards))
         # Get folder name of first library candidate
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
+        if self.config["path_link_in"]:
+            folder_name = wildcards.library_name
         # Perform the command generation
         lines = []
         tpl = (

--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -813,18 +813,25 @@ class LinkInPathGenerator:
     """Helper class for generating paths to link in"""
 
     def __init__(
-        self, work_dir, data_set_infos, config_paths, cache_file_name=".snappy_path_cache"
+        self,
+        work_dir,
+        data_set_infos,
+        config_paths,
+        cache_file_name=".snappy_path_cache",
+        preprocessed_path="",
     ):
         #: Working directory
         self.work_dir = work_dir
         #: Data set info list from configuration
-        self.data_set_infos = data_set_infos
+        self.data_set_infos = [
+            self._update_datasetinfo(x, preprocessed_path) for x in data_set_infos
+        ]
         #: Path to configuration files, used for invalidating cache
         self.config_paths = config_paths
         #: Name of cache file to create
         self.cache_file_name = cache_file_name
         #: File system crawler to use
-        invalidate_paths_list = self._merge_cache_invalidate_paths(data_set_infos)
+        invalidate_paths_list = self._merge_cache_invalidate_paths(self.data_set_infos)
         invalidate_paths_list += config_paths
         self.crawler = FileSystemCrawler(
             os.path.join(self.work_dir, self.cache_file_name), invalidate_paths_list
@@ -873,6 +880,21 @@ class LinkInPathGenerator:
                         yield src_dir, path_infix, filename
         # Finally, save the cache
         self.crawler.save_cache()
+
+    def _update_datasetinfo(self, data_set_info, preprocessed_path=""):
+        return DataSetInfo(
+            name=data_set_info.name,
+            sheet_path=data_set_info.sheet_path,
+            base_paths=data_set_info.base_paths,
+            search_paths=[preprocessed_path] if preprocessed_path else data_set_info.search_paths,
+            search_patterns=data_set_info.search_patterns,
+            sheet_type=data_set_info.sheet_type,
+            is_background=data_set_info.is_background,
+            naming_scheme=data_set_info.naming_scheme,
+            mixed_se_pe=data_set_info.mixed_se_pe,
+            sodar_uuid=data_set_info.sodar_uuid,
+            sodar_title=data_set_info.sodar_title,
+        )
 
     @classmethod
     def _get_shell_cmd_root_paths(cls, info):
@@ -978,7 +1000,11 @@ class LinkInStep(BaseStepPart):
         self.base_pattern_out = "work/input_links/{library_name}/.done"
         # Path generator.
         self.path_gen = LinkInPathGenerator(
-            self.parent.work_dir, self.parent.data_set_infos, self.parent.config_lookup_paths
+            self.parent.work_dir,
+            self.parent.data_set_infos,
+            self.parent.config_lookup_paths,
+            cache_file_name=".snappy_path_cache",
+            preprocessed_path=self.config["path_link_in"],
         )
 
     def get_input_files(self, action):

--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 """Base classes for the actual pipeline steps"""
 
-from collections import OrderedDict
-from collections.abc import MutableMapping
-from fnmatch import fnmatch
-from functools import lru_cache
-from io import StringIO
 import itertools
 import os
 import os.path
 import sys
 import typing
+from collections import OrderedDict
+from collections.abc import MutableMapping
+from fnmatch import fnmatch
+from functools import lru_cache
+from io import StringIO
 
+import ruamel.yaml as ruamel_yaml
 from biomedsheets import io_tsv
 from biomedsheets.io import SheetBuilder, json_loads_ordered
 from biomedsheets.models import SecondaryIDNotFoundException
@@ -22,7 +23,6 @@ from biomedsheets.shortcuts import (
     write_pedigree_to_ped,
     write_pedigrees_to_ped,
 )
-import ruamel.yaml as ruamel_yaml
 from snakemake.io import touch
 
 from snappy_pipeline.base import (

--- a/snappy_pipeline/workflows/abstract/__init__.py
+++ b/snappy_pipeline/workflows/abstract/__init__.py
@@ -1,18 +1,17 @@
 # -*- coding: utf-8 -*-
 """Base classes for the actual pipeline steps"""
 
-import itertools
-import os
-import os.path
-import sys
-import typing
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from fnmatch import fnmatch
 from functools import lru_cache
 from io import StringIO
+import itertools
+import os
+import os.path
+import sys
+import typing
 
-import ruamel.yaml as ruamel_yaml
 from biomedsheets import io_tsv
 from biomedsheets.io import SheetBuilder, json_loads_ordered
 from biomedsheets.models import SecondaryIDNotFoundException
@@ -23,6 +22,7 @@ from biomedsheets.shortcuts import (
     write_pedigree_to_ped,
     write_pedigrees_to_ped,
 )
+import ruamel.yaml as ruamel_yaml
 from snakemake.io import touch
 
 from snappy_pipeline.base import (

--- a/snappy_pipeline/workflows/adapter_trimming/Snakefile
+++ b/snappy_pipeline/workflows/adapter_trimming/Snakefile
@@ -70,16 +70,16 @@ rule adapter_trimming_link_out_fastq_run:  # localrule
 
 rule adapter_trimming_bbduk_run:
     input:
-        **wf. get_input_files("bbduk","run"),
+        **wf.get_input_files("bbduk", "run"),
     output:
-        **wf. get_output_files("bbduk","run"),
+        **wf.get_output_files("bbduk", "run"),
     threads: wf.get_resource("bbduk", "run", "threads")
     resources:
         time=wf.get_resource("bbduk", "run", "time"),
         memory=wf.get_resource("bbduk", "run", "memory"),
         partition=wf.get_resource("bbduk", "run", "partition"),
     log:
-        **wf. get_log_file("bbduk","run"),
+        **wf.get_log_file("bbduk", "run"),
     params:
         args=wf.substep_dispatch("bbduk", "get_args", "run"),
     wrapper:
@@ -91,16 +91,16 @@ rule adapter_trimming_bbduk_run:
 
 rule adapter_trimming_fastp_run:
     input:
-        **wf. get_input_files("fastp","run"),
+        **wf.get_input_files("fastp", "run"),
     output:
-        **wf. get_output_files("fastp","run"),
+        **wf.get_output_files("fastp", "run"),
     threads: wf.get_resource("fastp", "run", "threads")
     resources:
         time=wf.get_resource("fastp", "run", "time"),
         memory=wf.get_resource("fastp", "run", "memory"),
         partition=wf.get_resource("fastp", "run", "partition"),
     log:
-        **wf. get_log_file("fastp","run"),
+        **wf.get_log_file("fastp", "run"),
     params:
         args=wf.substep_dispatch("fastp", "get_args", "run"),
     wrapper:

--- a/snappy_pipeline/workflows/adapter_trimming/Snakefile
+++ b/snappy_pipeline/workflows/adapter_trimming/Snakefile
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""CUBI Pipeline adapter_trimming step Snakefile"""
+
+import os
+
+from snappy_pipeline import expand_ref
+from snappy_pipeline.workflows.adapter_trimming import AdapterTrimmingWorkflow
+
+__author__ = "Eric Blanc <eric.blanc@bihealth.de>"
+
+
+# Configuration ===============================================================
+
+
+configfile: "config.yaml"
+
+
+# Expand "$ref" JSON pointers in configuration (also works for YAML)
+config, lookup_paths, config_paths = expand_ref("config.yaml", config)
+
+# WorkflowImpl Object Setup ===================================================
+
+wf = AdapterTrimmingWorkflow(workflow, config, lookup_paths, config_paths, os.getcwd())
+
+# Rules =======================================================================
+
+
+localrules:
+    # Linking the FASTQ files in and linking out the alignments should
+    # be done locally by the Snakemake master process
+    adapter_trimming_link_in_run,
+    adapter_trimming_link_out_fastq_run,
+
+
+rule all:
+    input:
+        wf.get_result_files(),
+
+
+# House-Keeping ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Link in FASTQ files ---------------------------------------------------------
+
+
+rule adapter_trimming_link_in_run:
+    input:
+        wf.get_input_files("link_in", "run"),
+    output:
+        wf.get_output_files("link_in", "run"),
+    run:
+        shell(wf.get_shell_cmd("link_in", "run", wildcards))
+
+# Link out fastq files --------------------------------------------------------
+
+
+rule adapter_trimming_link_out_fastq_run:  # localrule
+    input:
+        wf.get_input_files("link_out_fastq", "run"),
+    output:
+        wf.get_output_files("link_out_fastq", "run"),
+    run:
+        shell(wf.get_shell_cmd("link_out_fastq", "run", wildcards))
+
+
+# Adapter trimming ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# bbduk -----------------------------------------------------------------------
+
+
+rule adapter_trimming_bbduk_run:
+    input:
+        **wf.get_input_files("bbduk", "run"),
+    output:
+        **wf.get_output_files("bbduk", "run"),
+    threads: wf.get_resource("bbduk", "run", "threads")
+    resources:
+        time=wf.get_resource("bbduk", "run", "time"),
+        memory=wf.get_resource("bbduk", "run", "memory"),
+        partition=wf.get_resource("bbduk", "run", "partition"),
+    log:
+        **wf.get_log_file("bbduk", "run"),
+    params:
+        args=wf.substep_dispatch("bbduk", "get_args", "run"),
+    wrapper:
+        wf.wrapper_path("bbduk/run")
+
+
+# fastp -----------------------------------------------------------------------
+
+
+rule adapter_trimming_fastp_run:
+    input:
+        **wf.get_input_files("fastp", "run"),
+    output:
+        **wf.get_output_files("fastp", "run"),
+    threads: wf.get_resource("fastp", "run", "threads")
+    resources:
+        time=wf.get_resource("fastp", "run", "time"),
+        memory=wf.get_resource("fastp", "run", "memory"),
+        partition=wf.get_resource("fastp", "run", "partition"),
+    log:
+        **wf.get_log_file("fastp", "run"),
+    params:
+        args=wf.substep_dispatch("fastp", "get_args", "run"),
+    wrapper:
+        wf.wrapper_path("fastp/run")

--- a/snappy_pipeline/workflows/adapter_trimming/Snakefile
+++ b/snappy_pipeline/workflows/adapter_trimming/Snakefile
@@ -50,6 +50,7 @@ rule adapter_trimming_link_in_run:
     run:
         shell(wf.get_shell_cmd("link_in", "run", wildcards))
 
+
 # Link out fastq files --------------------------------------------------------
 
 
@@ -69,16 +70,16 @@ rule adapter_trimming_link_out_fastq_run:  # localrule
 
 rule adapter_trimming_bbduk_run:
     input:
-        **wf.get_input_files("bbduk", "run"),
+        **wf. get_input_files("bbduk","run"),
     output:
-        **wf.get_output_files("bbduk", "run"),
+        **wf. get_output_files("bbduk","run"),
     threads: wf.get_resource("bbduk", "run", "threads")
     resources:
         time=wf.get_resource("bbduk", "run", "time"),
         memory=wf.get_resource("bbduk", "run", "memory"),
         partition=wf.get_resource("bbduk", "run", "partition"),
     log:
-        **wf.get_log_file("bbduk", "run"),
+        **wf. get_log_file("bbduk","run"),
     params:
         args=wf.substep_dispatch("bbduk", "get_args", "run"),
     wrapper:
@@ -90,16 +91,16 @@ rule adapter_trimming_bbduk_run:
 
 rule adapter_trimming_fastp_run:
     input:
-        **wf.get_input_files("fastp", "run"),
+        **wf. get_input_files("fastp","run"),
     output:
-        **wf.get_output_files("fastp", "run"),
+        **wf. get_output_files("fastp","run"),
     threads: wf.get_resource("fastp", "run", "threads")
     resources:
         time=wf.get_resource("fastp", "run", "time"),
         memory=wf.get_resource("fastp", "run", "memory"),
         partition=wf.get_resource("fastp", "run", "partition"),
     log:
-        **wf.get_log_file("fastp", "run"),
+        **wf. get_log_file("fastp","run"),
     params:
         args=wf.substep_dispatch("fastp", "get_args", "run"),
     wrapper:

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -26,14 +26,14 @@ Consider the following data set definition from the main configuration file.
 
     data_sets:
       first_batch:
-        file: 01_first_batch.json
+        file: 01_first_batch.tsv
         search_patterns:
           # Note that currently only "left" and "right" key known
           - {'left': '*/L???/*_R1.fastq.gz', 'right': '*/L???/*_R2.fastq.gz'}
         search_paths: ['../input/01_first_batch']
 
 Here, the data set ``first_batch`` is defined.  The sample sheet file is named
-``01_first_batch.json`` and looked for in the relative path to the configuration file.  The input
+``01_first_batch.tsv`` and looked for in the relative path to the configuration file.  The input
 search will be start in the (one, but could be more than one) path ``../input/01_first_batch``
 (relative to the directory containing the configuration file).  The sample sheet provides a
 ``folderName`` ``extraInfo`` entry for each NGS library.  This folder name is searched for (e.g.,
@@ -43,8 +43,11 @@ search will be start in the (one, but could be more than one) path ``../input/01
 Currently, the only supported keys in the ``search_patterns`` dict are ``"left"`` and ``"right""``
 (the latter can be omitted when only searching for single-end reads).
 
-Consider the following example::
-    ../input/
+Consider the following example:
+
+::
+
+  ../input/
     `-- 01_first_batch
         |-- P001-N1-DNA1-WES1
         |   `-- 42KF5AAXX

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -447,12 +447,11 @@ class AdapterTrimmingStepPart(BaseStepPart):
             preprocessed_path=self.config["path_link_in"],
         )
 
-    @classmethod
     @dictify
-    def get_input_files(cls, action):
+    def get_input_files(self, action):
         """Return input files"""
         # Validate action
-        cls._validate_action(action)
+        self._validate_action(action)
         yield "done", "work/input_links/{library_name}/.done"
 
     @dictify
@@ -524,10 +523,6 @@ class AdapterTrimmingStepPart(BaseStepPart):
             }
             path_info[input_path] = paths
         return path_info
-
-    @classmethod
-    def _validate_action(cls, action):
-        assert action in cls.actions
 
 
 class BbdukStepPart(AdapterTrimmingStepPart):
@@ -627,7 +622,11 @@ class LinkOutFastqStepPart(BaseStepPart):
         cmd = cmd + " ; fns=$(find $din_ -type f -printf '%P\\n')"
         cmd = (
             cmd
-            + " ; for fn in $fns ; do if [[ ! -L $din_/$fn ]] ; then mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn ; fi ; done"
+            + " ; for fn in $fns ; do"
+            + "     if [[ ! -L $din_/$fn ]] ; then"
+            + "       mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn"
+            + "   ; fi"
+            + " ; done"
         )
         return "\n".join((cmd.format(in_=in_, out=out) for in_, out in zip(ins, outs)))
 

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -142,7 +142,6 @@ import os
 from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import expand
 
-from snappy_pipeline.base import UnsupportedActionException
 from snappy_pipeline.utils import dictify, listify
 from snappy_pipeline.workflows.abstract import (
     BaseStep,
@@ -537,15 +536,9 @@ class BbdukStepPart(AdapterTrimmingStepPart):
         :type action: str
 
         :return: Returns ResourceUsage for step.
-
-        :raises UnsupportedActionException: if action not in class defined list of valid actions.
         """
         # Validate action
         self._validate_action(action)
-        if action not in self.actions:
-            actions_str = ", ".join(self.actions)
-            error_message = f"Action '{action}' is not supported. Valid options: {actions_str}"
-            raise UnsupportedActionException(error_message)
         return ResourceUsage(
             threads=self.config["bbduk"]["num_threads"],
             time="12:00:00",  # 40 hours
@@ -566,15 +559,9 @@ class FastpStepPart(AdapterTrimmingStepPart):
         :type action: str
 
         :return: Returns ResourceUsage for step.
-
-        :raises UnsupportedActionException: if action not in class defined list of valid actions.
         """
         # Validate action
         self._validate_action(action)
-        if action not in self.actions:
-            actions_str = ", ".join(self.actions)
-            error_message = f"Action '{action}' is not supported. Valid options: {actions_str}"
-            raise UnsupportedActionException(error_message)
         return ResourceUsage(
             threads=self.config["fastp"]["num_threads"],
             time="12:00:00",  # 60 hours

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -59,8 +59,8 @@ The following adpter trimming tools are currently available
 
 """
 
-from collections import OrderedDict
 import os
+from collections import OrderedDict
 
 from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import expand
@@ -76,7 +76,6 @@ from snappy_pipeline.workflows.abstract import (
     ResourceUsage,
     get_ngs_library_folder_name,
 )
-
 
 #: Adatper trimming tools
 TRIMMERS = ("bbduk", "fastp")

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -8,37 +8,111 @@ The tools are highly configurable, and provide feedback of the success of the op
 Step Input
 ==========
 
-Adapter trimming starts at the raw RNA-seq reads.  Thus, the input is very similar to one of
-:ref:`ngs_mapping step <step_ngs_mapping>`.
+For each library defined in all sample sheets, the instances of this step will search for the input
+files according to the configuration.  The found read files will be linked into
+``work/input_links/{library_name}`` (status quo, not a output path, thus path not guaranteed
+to be stable between minor versions).
 
-See :ref:`ngs_mapping_step_input` for more information.
+The search paths can be overridden using the step configuration option ``path_link_in``.
+``path_link_in`` is a general features that enables pre-processing steps, typically before mapping.
+
+----------------------
+Data Set Configuration
+----------------------
+
+Consider the following data set definition from the main configuration file.
+
+.. code-block:: yaml
+
+    data_sets:
+      first_batch:
+        file: 01_first_batch.json
+        search_patterns:
+          # Note that currently only "left" and "right" key known
+          - {'left': '*/L???/*_R1.fastq.gz', 'right': '*/L???/*_R2.fastq.gz'}
+        search_paths: ['../input/01_first_batch']
+
+Here, the data set ``first_batch`` is defined.  The sample sheet file is named
+``01_first_batch.json`` and looked for in the relative path to the configuration file.  The input
+search will be start in the (one, but could be more than one) path ``../input/01_first_batch``
+(relative to the directory containing the configuration file).  The sample sheet provides a
+``folderName`` ``extraInfo`` entry for each NGS library.  This folder name is searched for (e.g.,
+``P001-N1-DNA1-WES``).  Once such a folder is found, the patterns in the values of the dict
+``search_patterns`` are used for locating the paths of the actual files.
+
+Currently, the only supported keys in the ``search_patterns`` dict are ``"left"`` and ``"right""``
+(the latter can be omitted when only searching for single-end reads).
+
+Consider the following example::
+    ../input/
+    `-- 01_first_batch
+        |-- P001-N1-DNA1-WES1
+        |   `-- 42KF5AAXX
+        |       `-- L001
+        |           |-- P001-N1-DNA1-WES1_R1.fastq.gz
+        |           |-- P001-N1-DNA1-WES1_R1.fastq.gz.md5
+        |           |-- P001-N1-DNA1-WES1_R2.fastq.gz
+        |           `-- P001-N1-DNA1-WES1_R2.fastq.gz.md5
+        [...]
+
+Here, the folder ``01_first_batch`` will be searched for a directory named ``P001-N1-DNA1-WES``.
+After finding, the relative paths ``42KF5AAXX/L001/P001-N1-DNA1-WES1_R1.fastq.gz`` and
+``42KF5AAXX/L001/P001-N1-DNA1-WES1_R2.fastq.gz`` will be found and used for the left/right parts of
+a paired read set.
+
+------------------------------------------------------
+Overriding data set confguration with ``path_link_in``
+------------------------------------------------------
+
+When the config option ``path_link_in`` is set, it takes precedence on the search paths defined in the
+data set configuration.
+
+The searching for input files will follow the same rules as defined in the data set configuration,
+except that the base path for the search provided by one single path defined in the configuration of the
+step.
+
+
+Mixing Single-End and Paired-End Reads
+======================================
+
+By default, it is checked that for each ``search_pattern``, the same number of matching files
+has to be found, otherwise directories are ignored.  The reason is to reduce the number of
+possible errors when linking in files.  You can change this behaviour by specifying
+``mixed_se_pe: True`` in the data set information.  Then, it will be allowed to have the matches
+for the ``right`` entry to be empty.  However, you will need to consistently have either SE or
+PE data for each library; it is allowed to mix SE and PE libraries within one project but not
+to have PE and SE data for one library.
+
+Note that mixing single-end and paired-end reads is not (yet) supported when overriding the data set
+configuration by setting a value to the configuration option ``path_link_in``.
+
 
 ===========
 Step Output
 ===========
 
 Adapter trimming will be performed for all NGS libraries in all sample sheets.  For each combination
-of tool library, a directory ``{tool}.{lib_name}-{lib_pk}/out`` will be created.
-Therein, trimmed fastq files will be created, together with fastq files for reads that might be
-filtered out by the process.
+of tool library, a directory ``{tool}/{lib_name}-{lib_pk}/out`` will be created.
+Therein, trimmed fastq files will be created.
 
-For example, it might look as follows for the example from above:
+The input structure and file names will be maintained on output.  For example, it might look as
+follows for the example from above:
 
 ::
 
     output/
-    +-- bbduk.P001-N1-DNA1-WES1
+    +-- bbduk
     |   `-- out
-    |       |-- Sample001_Lane_001_R1.fastq.gz
-    |       |-- Sample001_Lane_001_R2.fastq.gz
-    |       |-- Sample001_Lane_002_R1.fastq.gz
-    |       |-- Sample001_Lane_002_R2.fastq.gz
-    |       |-- Sample001_Lane_001_R1.fastq.gz.md5
-    |       |-- Sample001_Lane_001_R2.fastq.gz.md5
-    |       |-- Sample001_Lane_002_R1.fastq.gz.md5
-    |       |-- Sample001_Lane_002_R2.fastq.gz.md5
-    |       `-- .done
+    |       `-- P001-N1-DNA1-WES1
+    |           |-- 42KF5AAXX
+    |           |   `-- L001
+    |           |       |-- P001-N1-DNA1-WES1_R1.fastq.gz
+    |           |       |-- P001-N1-DNA1-WES1_R1.fastq.gz.md5
+    |           |       |-- P001-N1-DNA1-WES1_R2.fastq.gz
+    |           |       `-- P001-N1-DNA1-WES1_R2.fastq.gz.md5
+    |           `-- .done
     [...]
+
 
 =====================
 Default Configuration
@@ -72,7 +146,6 @@ from snappy_pipeline.workflows.abstract import (
     BaseStepPart,
     LinkInPathGenerator,
     LinkInStep,
-    LinkOutStepPart,
     ResourceUsage,
     get_ngs_library_folder_name,
 )
@@ -82,29 +155,271 @@ TRIMMERS = ("bbduk", "fastp")
 
 #: Default configuration for the hla_typing schema
 DEFAULT_CONFIG = r"""
-# Default configuration ngs_mapping
+# Default configuration adapter_trimming
 step_config:
   adapter_trimming:
-    path_link_in: ""
+    path_link_in: ""  # OPTIONAL Override data set configuration search paths for FASTQ files
     tools:
       - bbduk
+      - fastp
     bbduk:
-      adapter_sequences: REQUIRED # REQUIRED
+      adapter_sequences: []  # REQUIRED
+      # - /fast/work/groups/cubi/projects/biotools/static_data/app_support/bbtools/39.01/resources/adapters.fa
+      # - /fast/work/groups/cubi/projects/biotools/static_data/app_support/bbtools/39.01/resources/phix174_ill.ref.fa.gz
+      # Note: The author recommends setting tpe=t & tbo=t when adapter trimming paired reads.
       num_threads: 8
-      parameters:  # Taken from https://github.com/ewels/MultiQC/issues/1146#issuecomment-607980076
-      - "minlength=35"
-      - "trimq=25"
-      - "ktrim=r"
-      - "qtrim=rl"
-      - "k=18"
-      - "mink=11"
-      - "hdist=1"
-      - "trimpolyg=8" # Remove long polyG
+
+      # Non-default parameters from https://www.biostars.org/p/268221/
+      # & https://github.com/ewels/MultiQC/issues/1146#issuecomment-607980076
+
+      # Input parameters:
+      interleaved: auto    # (int) t/f overrides interleaved autodetection.
+      qin: auto            # Input quality offset: 33 (Sanger), 64, or auto.
+      copyundefined: f     # (cu) Process non-AGCT IUPAC reference bases by making all
+                           # possible unambiguous copies.  Intended for short motifs
+                           # or adapter barcodes, as time/memory use is exponential.
+
+      # Output parameters:
+      nzo: t               # Only write statistics about ref sequences with nonzero hits.
+      qout: auto           # Output quality offset: 33 (Sanger), 64, or auto.
+      statscolumns: 3      # (cols) Number of columns for stats output, 3 or 5.
+                           # 5 includes base counts.
+      rename: f            # Rename reads to indicate which sequences they matched.
+      refnames: f          # Use names of reference files rather than scaffold IDs.
+      trd: f               # Truncate read and ref names at the first whitespace.
+      ordered: f           # Set to true to output reads in same order as input.
+
+      # Histogram output parameters:
+      gcbins: auto         # Number gchist bins.  Set to 'auto' to use read length.
+      maxhistlen: 6000     # Set an upper bound for histogram lengths; higher uses
+                           # more memory.  The default is 6000 for some histograms
+                           # and 80000 for others.
+
+      # Histograms for mapped sam/bam files only:
+      histbefore: t        # Calculate histograms from reads before processing.
+      idbins: 100          # Number idhist bins.  Set to 'auto' to use read length.
+
+      # Processing parameters:
+      k: 21                # Kmer length used for finding contaminants.  Contaminants
+                           # shorter than k will not be found.  k must be at least 1.
+                           # bbduk default: 27
+      rcomp: t             # Look for reverse-complements of kmers in addition to
+                           # forward kmers.
+      maskmiddle: t        # (mm) Treat the middle base of a kmer as a wildcard, to
+                           # increase sensitivity in the presence of errors.
+      minkmerhits: 1       # (mkh) Reads need at least this many matching kmers
+                           # to be considered as matching the reference.
+      minkmerfraction: 0.0 # (mkf) A reads needs at least this fraction of its total
+                           # kmers to hit a ref, in order to be considered a match.
+                           # If this and minkmerhits are set, the greater is used.
+      mincovfraction: 0.0  # (mcf) A reads needs at least this fraction of its total
+                           # bases to be covered by ref kmers to be considered a match.
+                           # If specified, mcf overrides mkh and mkf.
+      hammingdistance: 1   # (hdist) Maximum Hamming distance for ref kmers (subs only).
+                           # Memory use is proportional to (3*K)^hdist.
+                           # bbduk default: 0
+      qhdist: 0            # Hamming distance for query kmers; impacts speed, not memory.
+      editdistance: 0      # (edist) Maximum edit distance from ref kmers (subs
+                           # and indels).  Memory use is proportional to (8*K)^edist.
+      hammingdistance2: 0  # (hdist2) Sets hdist for short kmers, when using mink.
+      qhdist2: 0           # Sets qhdist for short kmers, when using mink.
+      editdistance2: 0     # (edist2) Sets edist for short kmers, when using mink.
+      forbidn: f           # (fn) Forbids matching of read kmers containing N.
+                           # By default, these will match a reference 'A' if
+                           # hdist>0 or edist>0, to increase sensitivity.
+      removeifeitherbad: t # (rieb) Paired reads get sent to 'outmatch' if either is
+                           # match (or either is trimmed shorter than minlen).
+                           # Set to false to require both.
+      trimfailures: f      # Instead of discarding failed reads, trim them to 1bp.
+                           # This makes the statistics a bit odd.
+      findbestmatch: f     # (fbm) If multiple matches, associate read with sequence
+                           # sharing most kmers.  Reduces speed.
+      skipr1: f            # Don't do kmer-based operations on read 1.
+      skipr2: f            # Don't do kmer-based operations on read 2.
+      ecco: f              # For overlapping paired reads only.  Performs error-
+                           # correction with BBMerge prior to kmer operations.
+
+      # Trimming/Filtering/Masking parameters:
+      # Note - if ktrim, kmask, and ksplit are unset, the default behavior is kfilter.
+      # All kmer processing modes are mutually exclusive.
+      # Reads only get sent to 'outm' purely based on kmer matches in kfilter mode.
+
+      ktrim: r             # Trim reads to remove bases matching reference kmers.
+                           # Values:
+                           #   f (don't trim), [bbduk default]
+                           #   r (trim to the right),
+                           #   l (trim to the left)
+      kmask:               # Replace bases matching ref kmers with another symbol.
+                           # Allows any non-whitespace character, and processes short
+                           # kmers on both ends if mink is set.  'kmask: lc' will
+                           # convert masked bases to lowercase.
+      maskfullycovered: f  # (mfc) Only mask bases that are fully covered by kmers.
+      ksplit: f            # For single-ended reads only.  Reads will be split into
+                           # pairs around the kmer.  If the kmer is at the end of the
+                           # read, it will be trimmed instead.  Singletons will go to
+                           # out, and pairs will go to outm.  Do not use ksplit with
+                           # other operations such as quality-trimming or filtering.
+      mink: 11             # Look for shorter kmers at read tips down to this length,
+                           # when k-trimming or masking.  0 means disabled.  Enabling
+                           # this will disable maskmiddle.
+                           # bbduk default: 0 (disabled)
+      qtrim: rl            # Trim read ends to remove bases with quality below trimq.
+                           # Performed AFTER looking for kmers.  Values:
+                           #   rl (trim both ends),
+                           #   f (neither end),  [bbduk default]
+                           #   r (right end only),
+                           #   l (left end only),
+                           #   w (sliding window).
+      trimq: 25            # Regions with average quality BELOW this will be trimmed,
+                           # if qtrim is set to something other than f.  Can be a
+                           # floating-point number like 7.3.
+                           # Very strict quality threshold, bbduk default: 6
+      minlength: 35        # (ml) Reads shorter than this after trimming will be
+                           # discarded.  Pairs will be discarded if both are shorter.
+                           # bbduk default: 10
+      mlf: 0               # (minlengthfraction) Reads shorter than this fraction of
+                           # original length after trimming will be discarded.
+      minavgquality: 0     # (maq) Reads with average quality (after trimming) below
+                           # this will be discarded.
+      maqb: 0              # If positive, calculate maq from this many initial bases.
+      minbasequality: 0    # (mbq) Reads with any base below this quality (after
+                           # trimming) will be discarded.
+      maxns: -1            # If non-negative, reads with more Ns than this
+                           # (after trimming) will be discarded.
+      mcb: 0               # (minconsecutivebases) Discard reads without at least
+                           # this many consecutive called bases.
+      ottm: f              # (outputtrimmedtomatch) Output reads trimmed to shorter
+                           # than minlength to outm rather than discarding.
+      tp: 0                # (trimpad) Trim this much extra around matching kmers.
+      tbo: f               # (trimbyoverlap) Trim adapters based on where paired
+                           # reads overlap.
+      strictoverlap: t     # Adjust sensitivity for trimbyoverlap mode.
+      minoverlap: 14       # Require this many bases of overlap for detection.
+      mininsert: 40        # Require insert size of at least this for overlap.
+                           # Should be reduced to 16 for small RNA sequencing.
+      tpe: f               # (trimpairsevenly) When kmer right-trimming, trim both
+                           # reads to the minimum length of either.
+      forcetrimleft: 0     # (ftl) If positive, trim bases to the left of this position
+                           # (exclusive, 0-based).
+      forcetrimright: 0    # (ftr) If positive, trim bases to the right of this position
+                           # (exclusive, 0-based).
+      forcetrimright2: 0   # (ftr2) If positive, trim this many bases on the right end.
+      forcetrimmod: 5      # (ftm) If positive, right-trim length to be equal to zero,
+                           # modulo this number.
+                           # bbduk default: 0
+      restrictleft: 0      # If positive, only look for kmer matches in the
+                           # leftmost X bases.
+      restrictright: 0     # If positive, only look for kmer matches in the
+                           # rightmost X bases.
+      mingc: 0             # Discard reads with GC content below this.
+      maxgc: 1             # Discard reads with GC content above this.
+      # gcpairs: t           # Use average GC of paired reads.    Deprecated option?
+      #                      # Also affects gchist.
+      tossjunk: f          # Discard reads with invalid characters as bases.
+      swift: f             # Trim Swift sequences: Trailing C/T/N R1, leading G/A/N R2.
+
+      # Header-parsing parameters - these require Illumina headers:
+      chastityfilter: f    # (cf) Discard reads with id containing ' 1:Y:' or ' 2:Y:'.
+      barcodefilter: f     # Remove reads with unexpected barcodes if barcodes is set,
+                           # or barcodes containing 'N' otherwise.  A barcode must be
+                           # the last part of the read header.  Values:
+                           #   t:     Remove reads with bad barcodes.
+                           #   f:     Ignore barcodes.
+                           #   crash: Crash upon encountering bad barcodes.
+      barcodes: ""         # File of barcodes.
+      xmin: -1             # If positive, discard reads with a lesser X coordinate.
+      ymin: -1             # If positive, discard reads with a lesser Y coordinate.
+      xmax: -1             # If positive, discard reads with a greater X coordinate.
+      ymax: -1             # If positive, discard reads with a greater Y coordinate.
+
+      # Polymer trimming:
+      trimpolya: 0         # If greater than 0, trim poly-A or poly-T tails of
+                           # at least this length on either end of reads.
+      trimpolygleft: 0     # If greater than 0, trim poly-G prefixes of at least this
+                           # length on the left end of reads.  Does not trim poly-C.
+      trimpolygright: 0    # If greater than 0, trim poly-G tails of at least this
+                           # length on the right end of reads.  Does not trim poly-C.
+      trimpolyg: 8         # This sets both left and right at once.
+                           # bbduk default: don't trim polyG (trimpolyg=0)
+      filterpolyg: 0       # If greater than 0, remove reads with a poly-G prefix of
+                           # at least this length (on the left).
+      # Note: there are also equivalent poly-C flags.
+
+      # Entropy/Complexity parameters:
+      entropy: -1          # Set between 0 and 1 to filter reads with entropy below
+                           # that value.  Higher is more stringent.
+      entropywindow: 50    # Calculate entropy using a sliding window of this length.
+      entropyk: 5          # Calculate entropy using kmers of this length.
+      minbasefrequency: 0  # Discard reads with a minimum base frequency below this.
+      entropytrim: f       # Values:
+                           #    f:  (false) Do not entropy-trim.
+                           #    r:  (right) Trim low entropy on the right end only.
+                           #    l:  (left) Trim low entropy on the left end only.
+                           #    rl: (both) Trim low entropy on both ends.
+      entropymask: f       # Values:
+                           #    f:  (filter) Discard low-entropy sequences.
+                           #    t:  (true) Mask low-entropy parts of sequences with N.
+                           #    lc: Change low-entropy parts of sequences to lowercase.
+      entropymark: f       # Mark each base with its entropy value.  This is on a scale
+                           # of 0-41 and is reported as quality scores, so the output
+                           # should be fastq or fasta+qual.
+      # NOTE: If set, entropytrim overrides entropymask.
+
+      # Cardinality estimation:
+      cardinality: f       # (loglog) Count unique kmers using the LogLog algorithm.
+      cardinalityout: f    # (loglogout) Count unique kmers in output reads.
+      loglogk: 31          # Use this kmer length for counting.
+      loglogbuckets: 2048  # Use this many buckets for counting.
+
     fastp:
       num_threads: 4
-      parameters:
-      - "--trim_poly_g"
-      - "--poly_g_min_len 8"
+
+      trim_front1: 0                      # trimming how many bases in front for read1, default is 0 (int [=0])
+      trim_tail1: 0                       # trimming how many bases in tail for read1, default is 0 (int [=0])
+      max_len1: 0                         # if read1 is longer than max_len1, then trim read1 at its tail to make it as long as max_len1. Default 0 means no limitation (int [=0])
+      trim_front2: 0                      # trimming how many bases in front for read2. If it's not specified, it will follow read1's settings (int [=0])
+      trim_tail2: 0                       # trimming how many bases in tail for read2. If it's not specified, it will follow read1's settings (int [=0])
+      max_len2: 0                         # if read2 is longer than max_len2, then trim read2 at its tail to make it as long as max_len2. Default 0 means no limitation. If it's not specified, it will follow read1's settings (int [=0])
+      dedup: False                        # enable deduplication to drop the duplicated reads/pairs
+      dup_calc_accuracy: 0                # accuracy level to calculate duplication (1~6), higher level uses more memory (1G, 2G, 4G, 8G, 16G, 24G). Default 1 for no-dedup mode, and 3 for dedup mode. (int [=0])
+      dont_eval_duplication: True         # don't evaluate duplication rate to save time and use less memory.
+      trim_poly_g: True                   # force polyG tail trimming, by default trimming is automatically enabled for Illumina NextSeq/NovaSeq data
+      poly_g_min_len: 8                   # the minimum length to detect polyG in the read tail. 10 by default. (int [=10])
+      trim_poly_x: False                  # enable polyX trimming in 3' ends.
+      poly_x_min_len: 10                  # the minimum length to detect polyX in the read tail. 10 by default. (int [=10])
+      cut_front: False                    # move a sliding window from front (5') to tail, drop the bases in the window if its mean quality < threshold, stop otherwise.
+      cut_tail: False                     # move a sliding window from tail (3') to front, drop the bases in the window if its mean quality < threshold, stop otherwise.
+      cut_right: False                    # move a sliding window from front to tail, if meet one window with mean quality < threshold, drop the bases in the window and the right part, and then stop.
+      cut_front_window_size: 4            # the window size option of cut_front, default to cut_window_size if not specified (int [=4])
+      cut_front_mean_quality: 20          # the mean quality requirement option for cut_front, default to cut_mean_quality if not specified (int [=20])
+      cut_tail_window_size: 4             # the window size option of cut_tail, default to cut_window_size if not specified (int [=4])
+      cut_tail_mean_quality: 20           # the mean quality requirement option for cut_tail, default to cut_mean_quality if not specified (int [=20])
+      cut_right_window_size: 4            # the window size option of cut_right, default to cut_window_size if not specified (int [=4])
+      cut_right_mean_quality: 20          # the mean quality requirement option for cut_right, default to cut_mean_quality if not specified (int [=20])
+      disable_quality_filtering: False    # quality filtering is enabled by default. If this option is specified, quality filtering is disabled
+      qualified_quality_phred: 15         # the quality value that a base is qualified. Default 15 means phred quality >=Q15 is qualified. (int [=15])
+      unqualified_percent_limit: 40       # how many percents of bases are allowed to be unqualified (0~100). Default 40 means 40% (int [=40])
+      n_base_limit: 5                     # if one read's number of N base is >n_base_limit, then this read/pair is discarded. Default is 5 (int [=5])
+      average_qual: 0                     # if one read's average quality score <avg_qual, then this read/pair is discarded. Default 0 means no requirement (int [=0])
+      disable_length_filtering: False     # length filtering is enabled by default. If this option is specified, length filtering is disabled
+      length_required: 15                 # reads shorter than length_required will be discarded, default is 15. (int [=15])
+      length_limit: 0                     # reads longer than length_limit will be discarded, default 0 means no limitation. (int [=0])
+      low_complexity_filter: False        # enable low complexity filter. The complexity is defined as the percentage of base that is different from its next base (base[i] != base[i+1]).
+      complexity_threshold: 30            # the threshold for low complexity filter (0~100). Default is 30, which means 30% complexity is required. (int [=30])
+      filter_by_index1: ""                # specify a file contains a list of barcodes of index1 to be filtered out, one barcode per line (string [=])
+      filter_by_index2: ""                # specify a file contains a list of barcodes of index2 to be filtered out, one barcode per line (string [=])
+      filter_by_index_threshold: 0        # the allowed difference of index barcode for index filtering, default 0 means completely identical. (int [=0])
+      correction: False                   # enable base correction in overlapped regions (only for PE data), default is disabled
+      overlap_len_require: 30             # the minimum length to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. 30 by default. (int [=30])
+      overlap_diff_limit: 5               # the maximum number of mismatched bases to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. 5 by default. (int [=5])
+      overlap_diff_percent_limit: 20      # the maximum percentage of mismatched bases to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. Default 20 means 20%. (int [=20])
+      umi: False                          # enable unique molecular identifier (UMI) preprocessing
+      umi_loc: ""                         # specify the location of UMI, can be (index1/index2/read1/read2/per_index/per_read, default is none (string [=])
+      umi_len: 0                          # if the UMI is in read1/read2, its length should be provided (int [=0])
+      umi_prefix: ""                      # if specified, an underline will be used to connect prefix and UMI (i.e. prefix=UMI, UMI=AATTCG, final=UMI_AATTCG). No prefix by default (string [=])
+      umi_skip: 0                         # if the UMI is in read1/read2, fastp can skip several bases following UMI, default is 0 (int [=0])
+      overrepresentation_analysis: False  # enable overrepresented sequence analysis.
+
 """.lstrip()
 
 
@@ -133,21 +448,26 @@ class AdapterTrimmingStepPart(BaseStepPart):
     @dictify
     def get_input_files(cls, action):
         """Return input files"""
-        assert action == "run"
+        # Validate action
+        cls._validate_action(action)
         yield "done", "work/input_links/{library_name}/.done"
 
     @dictify
     def get_output_files(self, action):
         """Return output files"""
-        assert action == "run"
+        # Validate action
+        self._validate_action(action)
         return (
             ("out_done", self.base_path_out.format(trimmer=self.name) + "/out/.done"),
             ("report_done", self.base_path_out.format(trimmer=self.name) + "/report/.done"),
+            ("rejected_done", self.base_path_out.format(trimmer=self.name) + "/rejected/.done"),
         )
 
     @dictify
     def _get_log_file(self, action):
         """Return dict of log files."""
+        # Validate action
+        self._validate_action(action)
         _ = action
         prefix = "work/{trimmer}.{{library_name}}/log/{trimmer}.{{library_name}}".format(
             trimmer=self.__class__.name
@@ -168,33 +488,43 @@ class AdapterTrimmingStepPart(BaseStepPart):
         """Return function that maps wildcards to dict for input files"""
 
         def args_function(wildcards):
-            result = {
+            folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
+            if self.config["path_link_in"]:
+                folder_name = wildcards.library_name
+            reads_left = self._collect_reads(wildcards, folder_name, "")
+            reads_right = self._collect_reads(wildcards, folder_name, "right-")
+            return {
+                "library_name": wildcards.library_name,
                 "input": {
-                    "reads_left": list(
-                        sorted(self._collect_reads(wildcards, wildcards.library_name, ""))
-                    )
+                    "reads_left": {key: reads_left[key] for key in sorted(reads_left.keys())},
+                    "reads_right": {key: reads_right[key] for key in sorted(reads_right.keys())},
                 },
             }
-            reads_right = list(
-                sorted(self._collect_reads(wildcards, wildcards.library_name, "right-"))
-            )
-            if reads_right:
-                result["input"]["reads_right"] = reads_right
-            return result
 
-        assert action == "run", "Unsupported actions"
+        # Validate action
+        self._validate_action(action)
         return args_function
 
-    def _collect_reads(self, wildcards, library_name, prefix):
+    def _collect_reads(self, wildcards, folder_name, prefix):
         """Yield the path to reads
 
         Yields paths to right reads if prefix=='right-'
         """
-        _ = library_name
-        folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
         pattern_set_keys = ("right",) if prefix.startswith("right-") else ("left",)
+        path_info = {}
         for _, path_infix, filename in self.path_gen.run(folder_name, pattern_set_keys):
-            yield os.path.join(self.base_path_in, path_infix, filename).format(**wildcards)
+            input_path = os.path.join(self.base_path_in, path_infix, filename).format(**wildcards)
+            assert input_path not in path_info.keys()
+            paths = {
+                "relative_path": path_infix,
+                "filename": filename,
+            }
+            path_info[input_path] = paths
+        return path_info
+
+    @classmethod
+    def _validate_action(cls, action):
+        assert action in cls.actions
 
 
 class BbdukStepPart(AdapterTrimmingStepPart):
@@ -212,6 +542,8 @@ class BbdukStepPart(AdapterTrimmingStepPart):
 
         :raises UnsupportedActionException: if action not in class defined list of valid actions.
         """
+        # Validate action
+        self._validate_action(action)
         if action not in self.actions:
             actions_str = ", ".join(self.actions)
             error_message = f"Action '{action}' is not supported. Valid options: {actions_str}"
@@ -239,6 +571,8 @@ class FastpStepPart(AdapterTrimmingStepPart):
 
         :raises UnsupportedActionException: if action not in class defined list of valid actions.
         """
+        # Validate action
+        self._validate_action(action)
         if action not in self.actions:
             actions_str = ", ".join(self.actions)
             error_message = f"Action '{action}' is not supported. Valid options: {actions_str}"
@@ -250,7 +584,7 @@ class FastpStepPart(AdapterTrimmingStepPart):
         )
 
 
-class LinkOutFastqStepPart(LinkOutStepPart):
+class LinkOutFastqStepPart(BaseStepPart):
     """Link out the trimming results (all fastqs)"""
 
     name = "link_out_fastq"
@@ -265,32 +599,37 @@ class LinkOutFastqStepPart(LinkOutStepPart):
         """Return required input files"""
 
         def input_function(wildcards):
-            """Helper rapper function"""
+            """Helper wrapper function"""
             return expand(self.base_path_in.format(wildcards=wildcards), sub_dir=self.sub_dirs)
 
-        assert action == "run", "Unsupported action"
+        # Validate action
+        self._validate_action(action)
         return input_function
 
     def get_output_files(self, action):
         """Return output files that are generated by snappy-gatk_post_bam"""
-        assert action == "run", "Unsupported action"
+        # Validate action
+        self._validate_action(action)
         return expand(self.base_path_out, sub_dir=self.sub_dirs)
 
     def get_shell_cmd(self, action, wildcards):
         """Return call for linking out postprocessed (or not) files"""
-        assert action == "run", "Unsupported action"
+        # Validate action
+        self._validate_action(action)
         ins = expand(self.base_path_in.format(wildcards=wildcards), sub_dir=self.sub_dirs)
         outs = [s.format(**wildcards) for s in expand(self.base_path_out, sub_dir=self.sub_dirs)]
         assert len(ins) == len(outs)
 
         cmd = "din_=$(dirname {in_}) ; dout=$(dirname {out})"
-        cmd = cmd + " ; fns=$(ls $din_ | grep -Ev '^(rejected|unpaired|failed)_')"
+        cmd = cmd + " ; fns=$(find $din_ -type f -printf '%P\\n')"
         cmd = (
             cmd
-            + " ; for fn in $fns ; do if [[ ! -L $din_/$fn ]] ; then ln -sr $din_/$fn $dout/$fn ; fi ; done"
+            + " ; for fn in $fns ; do if [[ ! -L $din_/$fn ]] ; then mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn ; fi ; done"
         )
-        cmd = cmd + " ; test -L {in_} || ln -sr {in_} {out}"
         return "\n".join((cmd.format(in_=in_, out=out) for in_, out in zip(ins, outs)))
+
+    def _validate_action(self, action):
+        assert action == "run"
 
 
 class AdapterTrimmingWorkflow(BaseStep):

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -1,0 +1,335 @@
+# -*- coding: utf-8 -*-
+"""Implementation of the ``adapter_trimming`` step
+
+The adapter_trimming step performs adapter & quality trimming of reads (DNA or RNA).
+The tools are highly configurable, and provide feedback of the success of the operation.
+
+==========
+Step Input
+==========
+
+Adapter trimming starts at the raw RNA-seq reads.  Thus, the input is very similar to one of
+:ref:`ngs_mapping step <step_ngs_mapping>`.
+
+See :ref:`ngs_mapping_step_input` for more information.
+
+===========
+Step Output
+===========
+
+Adapter trimming will be performed for all NGS libraries in all sample sheets.  For each combination
+of tool library, a directory ``{tool}.{lib_name}-{lib_pk}/out`` will be created.
+Therein, trimmed fastq files will be created, together with fastq files for reads that might be
+filtered out by the process.
+
+For example, it might look as follows for the example from above:
+
+::
+
+    output/
+    +-- bbduk.P001-N1-DNA1-WES1
+    |   `-- out
+    |       |-- Sample001_Lane_001_R1.fastq.gz
+    |       |-- Sample001_Lane_001_R2.fastq.gz
+    |       |-- Sample001_Lane_002_R1.fastq.gz
+    |       |-- Sample001_Lane_002_R2.fastq.gz
+    |       |-- Sample001_Lane_001_R1.fastq.gz.md5
+    |       |-- Sample001_Lane_001_R2.fastq.gz.md5
+    |       |-- Sample001_Lane_002_R1.fastq.gz.md5
+    |       |-- Sample001_Lane_002_R2.fastq.gz.md5
+    |       `-- .done
+    [...]
+
+=====================
+Default Configuration
+=====================
+
+The default configuration is as follows.
+
+.. include:: DEFAULT_CONFIG_adapter_trimming.rst
+
+================================
+Available Adapter Trimming Tools
+================================
+
+The following adpter trimming tools are currently available
+
+- ``"bbduk"``
+- ``"fastp"``
+
+"""
+
+from collections import OrderedDict
+import os
+
+from biomedsheets.shortcuts import GenericSampleSheet
+from snakemake.io import expand
+
+from snappy_pipeline.base import UnsupportedActionException
+from snappy_pipeline.utils import dictify, listify
+from snappy_pipeline.workflows.abstract import (
+    BaseStep,
+    BaseStepPart,
+    LinkInPathGenerator,
+    LinkInStep,
+    LinkOutStepPart,
+    ResourceUsage,
+    get_ngs_library_folder_name,
+)
+
+
+#: Adatper trimming tools
+TRIMMERS = ("bbduk", "fastp")
+
+#: Default configuration for the hla_typing schema
+DEFAULT_CONFIG = r"""
+# Default configuration ngs_mapping
+step_config:
+  adapter_trimming:
+    path_link_in: ""
+    tools:
+      - bbduk
+    bbduk:
+      adapter_sequences: REQUIRED # REQUIRED
+      num_threads: 8
+      parameters:  # Taken from https://github.com/ewels/MultiQC/issues/1146#issuecomment-607980076
+      - "minlength=35"
+      - "trimq=25"
+      - "ktrim=r"
+      - "qtrim=rl"
+      - "k=18"
+      - "mink=11"
+      - "hdist=1"
+      - "trimpolyg=8" # Remove long polyG
+    fastp:
+      num_threads: 4
+      parameters:
+      - "--trim_poly_g"
+      - "--poly_g_min_len 8"
+""".lstrip()
+
+
+class AdapterTrimmingStepPart(BaseStepPart):
+    """Adapter trimming common features"""
+
+    #: Step name
+    name = ""
+
+    #: Class available actions
+    actions = ("run",)
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.base_path_in = "work/input_links/{library_name}"
+        self.base_path_out = "work/{trimmer}.{{library_name}}"
+        #: Path generator for linking in
+        self.path_gen = LinkInPathGenerator(
+            self.parent.work_dir,
+            self.parent.data_set_infos,
+            self.parent.config_lookup_paths,
+            preprocessed_path=self.config["path_link_in"],
+        )
+
+    @classmethod
+    @dictify
+    def get_input_files(cls, action):
+        """Return input files"""
+        assert action == "run"
+        yield "done", "work/input_links/{library_name}/.done"
+
+    @dictify
+    def get_output_files(self, action):
+        """Return output files"""
+        assert action == "run"
+        return (
+            ("out_done", self.base_path_out.format(trimmer=self.name) + "/out/.done"),
+            ("report_done", self.base_path_out.format(trimmer=self.name) + "/report/.done"),
+        )
+
+    @dictify
+    def _get_log_file(self, action):
+        """Return dict of log files."""
+        _ = action
+        prefix = "work/{trimmer}.{{library_name}}/log/{trimmer}.{{library_name}}".format(
+            trimmer=self.__class__.name
+        )
+        key_ext = (
+            ("log", ".log"),
+            ("conda_info", ".conda_info.txt"),
+            ("conda_list", ".conda_list.txt"),
+        )
+        yield "done", "work/{trimmer}.{{library_name}}/log/.done".format(
+            trimmer=self.__class__.name
+        )
+        for key, ext in key_ext:
+            yield key, prefix + ext
+            yield key + "_md5", prefix + ext + ".md5"
+
+    def get_args(self, action):
+        """Return function that maps wildcards to dict for input files"""
+
+        def args_function(wildcards):
+            result = {
+                "input": {
+                    "reads_left": list(
+                        sorted(self._collect_reads(wildcards, wildcards.library_name, ""))
+                    )
+                },
+            }
+            reads_right = list(
+                sorted(self._collect_reads(wildcards, wildcards.library_name, "right-"))
+            )
+            if reads_right:
+                result["input"]["reads_right"] = reads_right
+            return result
+
+        assert action == "run", "Unsupported actions"
+        return args_function
+
+    def _collect_reads(self, wildcards, library_name, prefix):
+        """Yield the path to reads
+
+        Yields paths to right reads if prefix=='right-'
+        """
+        _ = library_name
+        folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
+        pattern_set_keys = ("right",) if prefix.startswith("right-") else ("left",)
+        for _, path_infix, filename in self.path_gen.run(folder_name, pattern_set_keys):
+            yield os.path.join(self.base_path_in, path_infix, filename).format(**wildcards)
+
+
+class BbdukStepPart(AdapterTrimmingStepPart):
+    """bbduk adapter trimming"""
+
+    name = "bbduk"
+
+    def get_resource_usage(self, action):
+        """Get Resource Usage
+
+        :param action: Action (i.e., step) in the workflow, example: 'run'.
+        :type action: str
+
+        :return: Returns ResourceUsage for step.
+
+        :raises UnsupportedActionException: if action not in class defined list of valid actions.
+        """
+        if action not in self.actions:
+            actions_str = ", ".join(self.actions)
+            error_message = f"Action '{action}' is not supported. Valid options: {actions_str}"
+            raise UnsupportedActionException(error_message)
+        return ResourceUsage(
+            threads=self.config["bbduk"]["num_threads"],
+            time="12:00:00",  # 40 hours
+            memory="24000M",
+        )
+
+
+class FastpStepPart(AdapterTrimmingStepPart):
+    """fastp adapter trimming"""
+
+    #: Step name
+    name = "fastp"
+
+    def get_resource_usage(self, action):
+        """Get Resource Usage
+
+        :param action: Action (i.e., step) in the workflow, example: 'run'.
+        :type action: str
+
+        :return: Returns ResourceUsage for step.
+
+        :raises UnsupportedActionException: if action not in class defined list of valid actions.
+        """
+        if action not in self.actions:
+            actions_str = ", ".join(self.actions)
+            error_message = f"Action '{action}' is not supported. Valid options: {actions_str}"
+            raise UnsupportedActionException(error_message)
+        return ResourceUsage(
+            threads=self.config["fastp"]["num_threads"],
+            time="12:00:00",  # 60 hours
+            memory="24000M",
+        )
+
+
+class LinkOutFastqStepPart(LinkOutStepPart):
+    """Link out the trimming results (all fastqs)"""
+
+    name = "link_out_fastq"
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.base_path_in = "work/{wildcards.trimmer}.{wildcards.library_name}/{{sub_dir}}/.done"
+        self.base_path_out = "output/{{trimmer}}/{{library_name}}/{sub_dir}/.done"
+        self.sub_dirs = ["log", "report", "out"]
+
+    def get_input_files(self, action):
+        """Return required input files"""
+
+        def input_function(wildcards):
+            """Helper rapper function"""
+            return expand(self.base_path_in.format(wildcards=wildcards), sub_dir=self.sub_dirs)
+
+        assert action == "run", "Unsupported action"
+        return input_function
+
+    def get_output_files(self, action):
+        """Return output files that are generated by snappy-gatk_post_bam"""
+        assert action == "run", "Unsupported action"
+        return expand(self.base_path_out, sub_dir=self.sub_dirs)
+
+    def get_shell_cmd(self, action, wildcards):
+        """Return call for linking out postprocessed (or not) files"""
+        assert action == "run", "Unsupported action"
+        ins = expand(self.base_path_in.format(wildcards=wildcards), sub_dir=self.sub_dirs)
+        outs = [s.format(**wildcards) for s in expand(self.base_path_out, sub_dir=self.sub_dirs)]
+        assert len(ins) == len(outs)
+
+        cmd = "din_=$(dirname {in_}) ; dout=$(dirname {out})"
+        cmd = cmd + " ; fns=$(ls $din_ | grep -Ev '^(rejected|unpaired|failed)_')"
+        cmd = (
+            cmd
+            + " ; for fn in $fns ; do if [[ ! -L $din_/$fn ]] ; then ln -sr $din_/$fn $dout/$fn ; fi ; done"
+        )
+        cmd = cmd + " ; test -L {in_} || ln -sr {in_} {out}"
+        return "\n".join((cmd.format(in_=in_, out=out) for in_, out in zip(ins, outs)))
+
+
+class AdapterTrimmingWorkflow(BaseStep):
+    """Perform adapter & quality-based trimming"""
+
+    #: Step name
+    name = "adapter_trimming"
+
+    #: Default biomed sheet class
+    sheet_shortcut_class = GenericSampleSheet
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.register_sub_step_classes(
+            (BbdukStepPart, FastpStepPart, LinkInStep, LinkOutFastqStepPart)
+        )
+        self.ngs_library_name_to_ngs_library = OrderedDict()
+        for sheet in self.shortcut_sheets:
+            for ngs_library in sheet.all_ngs_libraries:
+                self.ngs_library_name_to_ngs_library[ngs_library.name] = ngs_library
+
+    @classmethod
+    def default_config_yaml(cls):
+        """Return default config YAML, to be overwritten by project-specific
+        one
+        """
+        return DEFAULT_CONFIG
+
+    @listify
+    def get_result_files(self):
+        """Return list of fixed name result files for the adapter trimming workflow"""
+        tpls = (
+            "output/{trimmer}/{ngs_library_name}/out/.done",
+            "output/{trimmer}/{ngs_library_name}/report/.done",
+            "output/{trimmer}/{ngs_library_name}/log/.done",
+        )
+        for sheet in self.shortcut_sheets:
+            for ngs_library in sheet.all_ngs_libraries:
+                for tool in self.config["tools"]:
+                    for tpl in tpls:
+                        yield tpl.format(trimmer=tool, ngs_library_name=ngs_library.name)

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -59,8 +59,8 @@ The following adpter trimming tools are currently available
 
 """
 
-import os
 from collections import OrderedDict
+import os
 
 from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import expand

--- a/snappy_pipeline/workflows/gene_expression_quantification/__init__.py
+++ b/snappy_pipeline/workflows/gene_expression_quantification/__init__.py
@@ -228,6 +228,8 @@ class SalmonStepPart(BaseStepPart):
         """
         _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
+        if self.config["path_link_in"]:
+            folder_name = library_name
         pattern_set_keys = ("right",) if prefix.startswith("right-") else ("left",)
         for _, path_infix, filename in self.path_gen.run(folder_name, pattern_set_keys):
             yield os.path.join(self.base_path_in, path_infix, filename).format(**wildcards)

--- a/snappy_pipeline/workflows/gene_expression_quantification/__init__.py
+++ b/snappy_pipeline/workflows/gene_expression_quantification/__init__.py
@@ -115,7 +115,7 @@ EXTENSIONS = {
 DEFAULT_CONFIG = r"""
 step_config:
   gene_expression_quantification:
-    path_link_in: ""
+    path_link_in: ""   # OPTIONAL Override data set configuration search paths for FASTQ files
     tools:
     - strandedness
     - featurecounts

--- a/snappy_pipeline/workflows/gene_expression_quantification/__init__.py
+++ b/snappy_pipeline/workflows/gene_expression_quantification/__init__.py
@@ -115,6 +115,7 @@ EXTENSIONS = {
 DEFAULT_CONFIG = r"""
 step_config:
   gene_expression_quantification:
+    path_link_in: ""
     tools:
     - strandedness
     - featurecounts
@@ -165,7 +166,10 @@ class SalmonStepPart(BaseStepPart):
             self.extensions["gene_sf"] = ".gene.sf"
             self.extensions["gene_sf_md5"] = ".gene.sf.md5"
         self.path_gen = LinkInPathGenerator(
-            self.parent.work_dir, self.parent.data_set_infos, self.parent.config_lookup_paths
+            self.parent.work_dir,
+            self.parent.data_set_infos,
+            self.parent.config_lookup_paths,
+            preprocessed_path=self.config["path_link_in"],
         )
 
     @classmethod

--- a/snappy_pipeline/workflows/gene_expression_quantification/__init__.py
+++ b/snappy_pipeline/workflows/gene_expression_quantification/__init__.py
@@ -226,7 +226,6 @@ class SalmonStepPart(BaseStepPart):
 
         Yields paths to right reads if prefix=='right-'
         """
-        _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
         if self.config["path_link_in"]:
             folder_name = library_name

--- a/snappy_pipeline/workflows/hla_typing/__init__.py
+++ b/snappy_pipeline/workflows/hla_typing/__init__.py
@@ -177,7 +177,6 @@ class OptiTypeStepPart(BaseStepPart):
 
         Yields paths to right reads if prefix=='right-'
         """
-        _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
         if self.config["path_link_in"]:
             folder_name = library_name

--- a/snappy_pipeline/workflows/hla_typing/__init__.py
+++ b/snappy_pipeline/workflows/hla_typing/__init__.py
@@ -179,6 +179,8 @@ class OptiTypeStepPart(BaseStepPart):
         """
         _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
+        if self.config["path_link_in"]:
+            folder_name = library_name
         pattern_set_keys = ("right",) if prefix.startswith("right-") else ("left",)
         for _, path_infix, filename in self.path_gen.run(folder_name, pattern_set_keys):
             yield os.path.join(self.base_path_in, path_infix, filename).format(**wildcards)

--- a/snappy_pipeline/workflows/hla_typing/__init__.py
+++ b/snappy_pipeline/workflows/hla_typing/__init__.py
@@ -87,6 +87,7 @@ DEFAULT_CONFIG = r"""
 step_config:
   hla_typing:
     path_ngs_mapping: ../ngs_mapping
+    path_link_in: ""
     tools:
       - optitype
     optitype:
@@ -116,7 +117,10 @@ class OptiTypeStepPart(BaseStepPart):
         self.extensions = EXT_VALUES
         #: Path generator for linking in
         self.path_gen = LinkInPathGenerator(
-            self.parent.work_dir, self.parent.data_set_infos, self.parent.config_lookup_paths
+            self.parent.work_dir,
+            self.parent.data_set_infos,
+            self.parent.config_lookup_paths,
+            preprocessed_path=self.config["path_link_in"],
         )
 
     @staticmethod

--- a/snappy_pipeline/workflows/hla_typing/__init__.py
+++ b/snappy_pipeline/workflows/hla_typing/__init__.py
@@ -54,8 +54,8 @@ The following HLA typing tools are currently available
 
 """
 
-from collections import OrderedDict
 import os
+from collections import OrderedDict
 
 from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import expand

--- a/snappy_pipeline/workflows/hla_typing/__init__.py
+++ b/snappy_pipeline/workflows/hla_typing/__init__.py
@@ -87,7 +87,7 @@ DEFAULT_CONFIG = r"""
 step_config:
   hla_typing:
     path_ngs_mapping: ../ngs_mapping
-    path_link_in: ""
+    path_link_in: ""   # OPTIONAL Override data set configuration search paths for FASTQ files
     tools:
       - optitype
     optitype:

--- a/snappy_pipeline/workflows/hla_typing/__init__.py
+++ b/snappy_pipeline/workflows/hla_typing/__init__.py
@@ -54,8 +54,8 @@ The following HLA typing tools are currently available
 
 """
 
-import os
 from collections import OrderedDict
+import os
 
 from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import expand

--- a/snappy_pipeline/workflows/ngs_data_qc/__init__.py
+++ b/snappy_pipeline/workflows/ngs_data_qc/__init__.py
@@ -11,8 +11,8 @@ The default configuration is as follows.
 
 """
 
-import os
 from itertools import chain
+import os
 
 from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import Namedlist, expand, touch

--- a/snappy_pipeline/workflows/ngs_data_qc/__init__.py
+++ b/snappy_pipeline/workflows/ngs_data_qc/__init__.py
@@ -104,6 +104,8 @@ class FastQcReportStepPart(BaseStepPart):
         """
         _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
+        if self.config["path_link_in"]:
+            folder_name = library_name
         pattern_set_keys = ("right",) if prefix.startswith("right-") else ("left",)
         for _, path_infix, filename in self.path_gen.run(folder_name, pattern_set_keys):
             yield os.path.join(self.base_path_in, path_infix, filename).format(**wildcards)

--- a/snappy_pipeline/workflows/ngs_data_qc/__init__.py
+++ b/snappy_pipeline/workflows/ngs_data_qc/__init__.py
@@ -11,8 +11,8 @@ The default configuration is as follows.
 
 """
 
-from itertools import chain
 import os
+from itertools import chain
 
 from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import Namedlist, expand, touch

--- a/snappy_pipeline/workflows/ngs_data_qc/__init__.py
+++ b/snappy_pipeline/workflows/ngs_data_qc/__init__.py
@@ -102,7 +102,6 @@ class FastQcReportStepPart(BaseStepPart):
 
         Yields paths to right reads if prefix=='right-'
         """
-        _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
         if self.config["path_link_in"]:
             folder_name = library_name

--- a/snappy_pipeline/workflows/ngs_data_qc/__init__.py
+++ b/snappy_pipeline/workflows/ngs_data_qc/__init__.py
@@ -32,6 +32,7 @@ DEFAULT_CONFIG = r"""
 # Default configuration ngs_mapping
 step_config:
   ngs_data_qc:
+    path_link_in: ""
     tools:
     - fastqc
 """
@@ -51,7 +52,10 @@ class FastQcReportStepPart(BaseStepPart):
         self.base_path_in = "work/input_links/{library_name}"
         #: Path generator for linking in
         self.path_gen = LinkInPathGenerator(
-            self.parent.work_dir, self.parent.data_set_infos, self.parent.config_lookup_paths
+            self.parent.work_dir,
+            self.parent.data_set_infos,
+            self.parent.config_lookup_paths,
+            preprocessed_path=self.config["path_link_in"],
         )
 
     def get_args(self, action):

--- a/snappy_pipeline/workflows/ngs_data_qc/__init__.py
+++ b/snappy_pipeline/workflows/ngs_data_qc/__init__.py
@@ -32,7 +32,7 @@ DEFAULT_CONFIG = r"""
 # Default configuration ngs_mapping
 step_config:
   ngs_data_qc:
-    path_link_in: ""
+    path_link_in: ""  # OPTIONAL Override data set configuration search paths for FASTQ files
     tools:
     - fastqc
 """

--- a/snappy_pipeline/workflows/ngs_mapping/__init__.py
+++ b/snappy_pipeline/workflows/ngs_mapping/__init__.py
@@ -512,7 +512,6 @@ class ReadMappingStepPart(BaseStepPart):
 
         Yields paths to right reads if prefix=='right-'
         """
-        _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
         if self.config["path_link_in"]:
             folder_name = library_name

--- a/snappy_pipeline/workflows/ngs_mapping/__init__.py
+++ b/snappy_pipeline/workflows/ngs_mapping/__init__.py
@@ -324,7 +324,7 @@ step_config:
       dna: []      # Required if DNA analysis; otherwise, leave empty. Example: 'bwa'.
       rna: []      # Required if RNA analysis; otherwise, leave empty. Example: 'star'.
       dna_long: [] # Required if long-read mapper used; otherwise, leave empty. Example: 'ngmlr'.
-    path_link_in: "" # Must be set for mapping to use trimmed fastqs
+    path_link_in: ""   # OPTIONAL Override data set configuration search paths for FASTQ files
     # Whether or not to compute coverage BED file
     compute_coverage_bed: false
     # Thresholds for targeted sequencing coverage QC.  Enabled by specifying

--- a/snappy_pipeline/workflows/ngs_mapping/__init__.py
+++ b/snappy_pipeline/workflows/ngs_mapping/__init__.py
@@ -514,6 +514,8 @@ class ReadMappingStepPart(BaseStepPart):
         """
         _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
+        if self.config["path_link_in"]:
+            folder_name = library_name
         pattern_set_keys = ("right",) if prefix.startswith("right-") else ("left",)
         seen = []
         for _, path_infix, filename in self.path_gen.run(folder_name, pattern_set_keys):

--- a/snappy_pipeline/workflows/ngs_mapping/__init__.py
+++ b/snappy_pipeline/workflows/ngs_mapping/__init__.py
@@ -324,6 +324,7 @@ step_config:
       dna: []      # Required if DNA analysis; otherwise, leave empty. Example: 'bwa'.
       rna: []      # Required if RNA analysis; otherwise, leave empty. Example: 'star'.
       dna_long: [] # Required if long-read mapper used; otherwise, leave empty. Example: 'ngmlr'.
+    path_link_in: "" # Must be set for mapping to use trimmed fastqs
     # Whether or not to compute coverage BED file
     compute_coverage_bed: false
     # Thresholds for targeted sequencing coverage QC.  Enabled by specifying
@@ -428,7 +429,10 @@ class ReadMappingStepPart(BaseStepPart):
         self.extensions = EXT_VALUES
         #: Path generator for linking in
         self.path_gen = LinkInPathGenerator(
-            self.parent.work_dir, self.parent.data_set_infos, self.parent.config_lookup_paths
+            self.parent.work_dir,
+            self.parent.data_set_infos,
+            self.parent.config_lookup_paths,
+            preprocessed_path=self.config["path_link_in"],
         )
 
     def get_args(self, action):

--- a/snappy_pipeline/workflows/somatic_gene_fusion_calling/__init__.py
+++ b/snappy_pipeline/workflows/somatic_gene_fusion_calling/__init__.py
@@ -62,7 +62,7 @@ GENE_FUSION_CALLERS = ("fusioncatcher", "jaffa", "pizzly", "hera", "star_fusion"
 DEFAULT_CONFIG = r"""
 step_config:
   somatic_gene_fusion_calling:
-    path_link_in: ""
+    path_link_in: ""  # OPTIONAL Override data set configuration search paths for FASTQ files
     tools: ['fusioncatcher', 'jaffa', 'arriba']
     fusioncatcher:
       data_dir: REQUIRED   # REQUIRED

--- a/snappy_pipeline/workflows/somatic_gene_fusion_calling/__init__.py
+++ b/snappy_pipeline/workflows/somatic_gene_fusion_calling/__init__.py
@@ -154,6 +154,8 @@ class SomaticGeneFusionCallingStepPart(BaseStepPart):
         """
         _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
+        if self.config["path_link_in"]:
+            folder_name = library_name
         pattern_set_keys = ("right",) if prefix.startswith("right-") else ("left",)
         for _, path_infix, filename in self.path_gen.run(folder_name, pattern_set_keys):
             yield os.path.join(self.base_path_in, path_infix, filename).format(**wildcards)

--- a/snappy_pipeline/workflows/somatic_gene_fusion_calling/__init__.py
+++ b/snappy_pipeline/workflows/somatic_gene_fusion_calling/__init__.py
@@ -152,7 +152,6 @@ class SomaticGeneFusionCallingStepPart(BaseStepPart):
 
         Yields paths to right reads if prefix=='right-'
         """
-        _ = library_name
         folder_name = get_ngs_library_folder_name(self.parent.sheets, wildcards.library_name)
         if self.config["path_link_in"]:
             folder_name = library_name

--- a/snappy_pipeline/workflows/somatic_gene_fusion_calling/__init__.py
+++ b/snappy_pipeline/workflows/somatic_gene_fusion_calling/__init__.py
@@ -62,7 +62,8 @@ GENE_FUSION_CALLERS = ("fusioncatcher", "jaffa", "pizzly", "hera", "star_fusion"
 DEFAULT_CONFIG = r"""
 step_config:
   somatic_gene_fusion_calling:
-    tools: ['fusioncatcher', 'jaffa']
+    path_link_in: ""
+    tools: ['fusioncatcher', 'jaffa', 'arriba']
     fusioncatcher:
       data_dir: REQUIRED   # REQUIRED
       configuration: null  # optional
@@ -118,7 +119,10 @@ class SomaticGeneFusionCallingStepPart(BaseStepPart):
         self.base_path_out = "work/{name}.{{library_name}}/out/.done".format(name=self.name)
         # Path generator for linking in
         self.path_gen = LinkInPathGenerator(
-            self.parent.work_dir, self.parent.data_set_infos, self.parent.config_lookup_paths
+            self.parent.work_dir,
+            self.parent.data_set_infos,
+            self.parent.config_lookup_paths,
+            preprocessed_path=self.config["path_link_in"],
         )
 
     @dictify

--- a/snappy_wrappers/wrappers/bbduk/environment.yaml
+++ b/snappy_wrappers/wrappers/bbduk/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bbmap =39

--- a/snappy_wrappers/wrappers/bbduk/run/environment.yaml
+++ b/snappy_wrappers/wrappers/bbduk/run/environment.yaml
@@ -1,0 +1,1 @@
+../environment.yaml

--- a/snappy_wrappers/wrappers/bbduk/run/wrapper.py
+++ b/snappy_wrappers/wrappers/bbduk/run/wrapper.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""CUBI+Snakemake wrapper code for bbduk: Snakemake wrapper.py
+"""
+
+from snakemake import shell
+
+__author__ = "Eric Blanc <manuel.holtgrewe@bih-charite.de>"
+
+shell.executable("/bin/bash")
+
+# Input fastqs are passed through snakemake.params.
+# snakemake.input is a .done file touched after linking files in.
+input_left = snakemake.params.args["input"]["reads_left"]
+input_right = snakemake.params.args["input"].get("reads_right", "")
+
+this_file = __file__
+
+this_step = snakemake.config["pipeline_step"]["name"]
+config = snakemake.config["step_config"][this_step]["bbduk"]
+
+shell(
+    r"""
+set -x
+
+# TODO: remove this again, is for fail early
+# Additional logging for transparency & reproducibility
+# Logging: Save a copy this wrapper (with the pickle details in the header)
+cp {this_file} $(dirname {snakemake.log.log})/wrapper_bwa.py
+
+# Write out information about conda installation.
+conda list >{snakemake.log.conda_list}
+conda info >{snakemake.log.conda_info}
+md5sum {snakemake.log.conda_list} >{snakemake.log.conda_list_md5}
+md5sum {snakemake.log.conda_info} >{snakemake.log.conda_info_md5}
+
+# Also pipe stderr to log file
+if [[ -n "{snakemake.log.log}" ]]; then
+    if [[ "$(set +e; tty; set -e)" != "" ]]; then
+        rm -f "{snakemake.log.log}" && mkdir -p $(dirname {snakemake.log.log})
+        exec 2> >(tee -a "{snakemake.log.log}" >&2)
+    else
+        rm -f "{snakemake.log.log}" && mkdir -p $(dirname {snakemake.log.log})
+        echo "No tty, logging disabled" >"{snakemake.log.log}"
+    fi
+fi
+
+# Setup auto-cleaned TMPDIR
+export TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+mkdir -p $TMPDIR/out $TMPDIR/report
+
+# Define left and right reads as Bash arrays
+declare -a reads_left=({input_left})
+declare -a reads_right=({input_right})
+
+# Check whether we have paired reads
+if [[ ${{#reads_right[*]}} -eq 0 ]]; then
+    paired=0
+else
+    paired=1
+fi
+
+# Check that we either have single-ended reds
+if [[ $paired -eq 1 ]] && [[ ${{#reads_right[*]}} -ne ${{#reads_left[*]}} ]]; then
+    >&2 echo "Number of right and left reads must be the same but was"
+    >&2 echo "  left:  $reads_left"
+    >&2 echo "  right: $reads_right"
+    exit 1
+fi
+
+# Start bbduk script
+
+for ((i = 0; i < ${{#reads_left[@]}}; i++)); do
+    # Find the base of filename (i.e. without fastq.gz (or derivatives) extension)
+    base=$(basename ${{reads_left[$i]}} | sed -e "s/\.f(ast)q(\.gz)?$//")
+    if [[ $paired -eq 1 ]]; then
+        # Common name between left & right reads (https://stackoverflow.com/questions/6973088/longest-common-prefix-of-two-strings-in-bash)
+        base=$(printf "%s\n%s\n" $(basename ${{reads_left[$i]}}) $(basename ${{reads_right[$i]}}) | sed -e 'N;s/^\(.*\).*\n\1.*$/\1/' | sed -e "s/_R$//")
+    fi
+
+    in=${{reads_left[$i]}}
+    out=$TMPDIR/out/$(basename $in)
+    outm=$TMPDIR/out/rejected_$(basename $in)
+
+    if [[ $paired -eq 1 ]]; then
+        in2=${{reads_right[$i]}}
+        out2=$TMPDIR/out/$(basename $in2)
+        outm2=$TMPDIR/out/rejected_$(basename $in2)
+    fi
+
+    bbduk.sh \
+        in=$in out=$out outm=$outm \
+        $(if [[ $paired -eq 1 ]]; then \
+            echo in2=$in2 out2=$out2 outm2=$outm2
+        fi) \
+        ref={config[adapter_sequences]} \
+        stats=$TMPDIR/report/stats_$base.tsv \
+        refstats=$TMPDIR/report/refstats_$base.tsv \
+        rpkm=$TMPDIR/report/rpkm_$base.tsv \
+        t={config[num_threads]} \
+        {config[parameters]}
+
+done
+
+pushd $TMPDIR/out
+fns=$(ls)
+for fn in $fns; do
+    md5sum $fn > $fn.md5
+done
+popd
+
+pushd $TMPDIR/report
+fns=$(ls)
+for fn in $fns; do
+    md5sum $fn > $fn.md5
+done
+popd
+
+d=$(dirname {snakemake.output.out_done})
+mkdir -p $d
+cp $TMPDIR/out/* $d
+
+d=$(dirname {snakemake.output.report_done})
+mkdir -p $d
+cp $TMPDIR/report/* $d
+
+touch {snakemake.output.out_done}
+touch {snakemake.output.report_done}
+
+"""
+)
+
+# Compute MD5 sums of logs.
+shell(
+    r"""
+md5sum {snakemake.log.log} >{snakemake.log.log_md5}
+"""
+)

--- a/snappy_wrappers/wrappers/bbduk/run/wrapper.py
+++ b/snappy_wrappers/wrappers/bbduk/run/wrapper.py
@@ -4,14 +4,39 @@
 
 from snakemake import shell
 
-__author__ = "Eric Blanc <manuel.holtgrewe@bih-charite.de>"
+__author__ = "Eric Blanc <eric.blanc@bih-charite.de>"
 
 shell.executable("/bin/bash")
 
 # Input fastqs are passed through snakemake.params.
 # snakemake.input is a .done file touched after linking files in.
+library_name = snakemake.params.args["library_name"]
 input_left = snakemake.params.args["input"]["reads_left"]
-input_right = snakemake.params.args["input"].get("reads_right", "")
+input_right = (
+    snakemake.params.args["input"]["reads_right"]
+    if snakemake.params.args["input"]["reads_right"]
+    else {}
+)
+
+input_path_left = list(input_left.keys())
+prefix_left = [x["relative_path"] for x in input_left.values()]
+filename_left = [x["filename"] for x in input_left.values()]
+
+assert len(input_path_left) == len(prefix_left)
+assert len(input_path_left) == len(filename_left)
+
+if input_right:
+    input_path_right = list(input_right.keys())
+    prefix_right = [x["relative_path"] for x in input_right.values()]
+    filename_right = [x["filename"] for x in input_right.values()]
+
+    assert len(input_path_left) == len(input_path_right)
+    assert len(prefix_left) == len(prefix_right)
+    assert len(filename_left) == len(filename_right)
+else:
+    input_path_right = []
+    prefix_right = []
+    filename_right = []
 
 this_file = __file__
 
@@ -25,7 +50,7 @@ set -x
 # TODO: remove this again, is for fail early
 # Additional logging for transparency & reproducibility
 # Logging: Save a copy this wrapper (with the pickle details in the header)
-cp {this_file} $(dirname {snakemake.log.log})/wrapper_bwa.py
+cp {this_file} $(dirname {snakemake.log.log})/wrapper_bbduk.py
 
 # Write out information about conda installation.
 conda list >{snakemake.log.conda_list}
@@ -47,11 +72,15 @@ fi
 # Setup auto-cleaned TMPDIR
 export TMPDIR=$(mktemp -d)
 trap "rm -rf $TMPDIR" EXIT
-mkdir -p $TMPDIR/out $TMPDIR/report
+mkdir -p $TMPDIR/out $TMPDIR/rejected $TMPDIR/report
 
 # Define left and right reads as Bash arrays
-declare -a reads_left=({input_left})
-declare -a reads_right=({input_right})
+declare -a reads_left=({input_path_left})
+declare -a reads_right=({input_path_right})
+declare -a prefix_left=({prefix_left})
+declare -a prefix_right=({prefix_right})
+declare -a filename_left=({filename_left})
+declare -a filename_right=({filename_right})
 
 # Check whether we have paired reads
 if [[ ${{#reads_right[*]}} -eq 0 ]]; then
@@ -71,61 +100,173 @@ fi
 # Start bbduk script
 
 for ((i = 0; i < ${{#reads_left[@]}}; i++)); do
-    # Find the base of filename (i.e. without fastq.gz (or derivatives) extension)
-    base=$(basename ${{reads_left[$i]}} | sed -e "s/\.f(ast)q(\.gz)?$//")
-    if [[ $paired -eq 1 ]]; then
-        # Common name between left & right reads (https://stackoverflow.com/questions/6973088/longest-common-prefix-of-two-strings-in-bash)
-        base=$(printf "%s\n%s\n" $(basename ${{reads_left[$i]}}) $(basename ${{reads_right[$i]}}) | sed -e 'N;s/^\(.*\).*\n\1.*$/\1/' | sed -e "s/_R$//")
-    fi
-
     in=${{reads_left[$i]}}
-    out=$TMPDIR/out/$(basename $in)
-    outm=$TMPDIR/out/rejected_$(basename $in)
+    out=$TMPDIR/out/${{prefix_left[$i]}}/${{filename_left[$i]}}
+    outm=$TMPDIR/rejected/${{prefix_left[$i]}}/${{filename_left[$i]}}
+    mkdir -p $(dirname $out) $(dirname $outm)
 
     if [[ $paired -eq 1 ]]; then
         in2=${{reads_right[$i]}}
-        out2=$TMPDIR/out/$(basename $in2)
-        outm2=$TMPDIR/out/rejected_$(basename $in2)
+        out2=$TMPDIR/out/${{prefix_right[$i]}}/${{filename_right[$i]}}
+        outm2=$TMPDIR/rejected/${{prefix_right[$i]}}/${{filename_right[$i]}}
+        mkdir -p $(dirname $out2) $(dirname $outm2)
     fi
+
+    # Find the base of filename (i.e. without fastq.gz (or derivatives) extension)
+    report="${{prefix_left[$i]}}/${{filename_left[$i]}}"
+    if [[ $paired -eq 1 ]]; then
+        report="${{report}}_${{filename_right[$i]}}"
+    fi
+    mkdir -p $TMPDIR/report/$report
+
+    # Create dummy files for debugging
+    # touch $out $outm $out2 $outm2
+    # for fn in $(echo "stats refstats rpkm bhist qhist qchist aqhist bqhist lhist phist enthist" | tr ' ' '\n'); do
+    #     touch $TMPDIR/report/$report/$fn.tsv
+    # done
 
     bbduk.sh \
         in=$in out=$out outm=$outm \
         $(if [[ $paired -eq 1 ]]; then \
             echo in2=$in2 out2=$out2 outm2=$outm2
         fi) \
-        ref={config[adapter_sequences]} \
-        stats=$TMPDIR/report/stats_$base.tsv \
-        refstats=$TMPDIR/report/refstats_$base.tsv \
-        rpkm=$TMPDIR/report/rpkm_$base.tsv \
+        ref=$(echo "{config[adapter_sequences]}" | tr ' ' ',') \
+        stats=$TMPDIR/report/$report/stats.tsv       \
+        refstats=$TMPDIR/report/$report/refstats.tsv \
+        rpkm=$TMPDIR/report/$report/rpkm.tsv         \
+        bhist=$TMPDIR/report/$report/bhist.tsv       \
+        qhist=$TMPDIR/report/$report/qhist.tsv       \
+        qchist=$TMPDIR/report/$report/qchist.tsv     \
+        aqhist=$TMPDIR/report/$report/aqhist.tsv     \
+        bqhist=$TMPDIR/report/$report/bqhist.tsv     \
+        lhist=$TMPDIR/report/$report/lhist.tsv       \
+        phist=$TMPDIR/report/$report/phist.tsv       \
+        enthist=$TMPDIR/report/$report/enthist.tsv   \
         t={config[num_threads]} \
-        {config[parameters]}
+        interleaved={config[interleaved]}             \
+        qin={config[qin]}                             \
+        copyundefined={config[copyundefined]}         \
+        nzo={config[nzo]}                             \
+        qout={config[qout]}                           \
+        statscolumns={config[statscolumns]}           \
+        rename={config[rename]}                       \
+        refnames={config[refnames]}                   \
+        trd={config[trd]}                             \
+        ordered={config[ordered]}                     \
+        gcbins={config[gcbins]}                       \
+        maxhistlen={config[maxhistlen]}               \
+        histbefore={config[histbefore]}               \
+        idbins={config[idbins]}                       \
+        k={config[k]}                                 \
+        rcomp={config[rcomp]}                         \
+        maskmiddle={config[maskmiddle]}               \
+        minkmerhits={config[minkmerhits]}             \
+        minkmerfraction={config[minkmerfraction]}     \
+        mincovfraction={config[mincovfraction]}       \
+        hammingdistance={config[hammingdistance]}     \
+        qhdist={config[qhdist]}                       \
+        editdistance={config[editdistance]}           \
+        hammingdistance2={config[hammingdistance2]}   \
+        qhdist2={config[qhdist2]}                     \
+        editdistance2={config[editdistance2]}         \
+        forbidn={config[forbidn]}                     \
+        removeifeitherbad={config[removeifeitherbad]} \
+        trimfailures={config[trimfailures]}           \
+        findbestmatch={config[findbestmatch]}         \
+        skipr1={config[skipr1]}                       \
+        skipr2={config[skipr2]}                       \
+        ecco={config[ecco]}                           \
+        ktrim={config[ktrim]}                         \
+        kmask={config[kmask]}                         \
+        maskfullycovered={config[maskfullycovered]}   \
+        ksplit={config[ksplit]}                       \
+        mink={config[mink]}                           \
+        qtrim={config[qtrim]}                         \
+        trimq={config[trimq]}                         \
+        minlength={config[minlength]}                 \
+        mlf={config[mlf]}                             \
+        minavgquality={config[minavgquality]}         \
+        maqb={config[maqb]}                           \
+        minbasequality={config[minbasequality]}       \
+        maxns={config[maxns]}                         \
+        mcb={config[mcb]}                             \
+        ottm={config[ottm]}                           \
+        tp={config[tp]}                               \
+        tbo={config[tbo]}                             \
+        strictoverlap={config[strictoverlap]}         \
+        minoverlap={config[minoverlap]}               \
+        mininsert={config[mininsert]}                 \
+        tpe={config[tpe]}                             \
+        forcetrimleft={config[forcetrimleft]}         \
+        forcetrimright={config[forcetrimright]}       \
+        forcetrimright2={config[forcetrimright2]}     \
+        forcetrimmod={config[forcetrimmod]}           \
+        restrictleft={config[restrictleft]}           \
+        restrictright={config[restrictright]}         \
+        mingc={config[mingc]}                         \
+        maxgc={config[maxgc]}                         \
+        tossjunk={config[tossjunk]}                   \
+        swift={config[swift]}                         \
+        chastityfilter={config[chastityfilter]}       \
+        barcodefilter={config[barcodefilter]}         \
+        $(if [[ -n "{config[barcodes]}" ]]; then \
+            echo barcodes={config[barcodes]}  
+        fi) \
+        xmin={config[xmin]}                           \
+        ymin={config[ymin]}                           \
+        xmax={config[xmax]}                           \
+        ymax={config[ymax]}                           \
+        trimpolya={config[trimpolya]}                 \
+        trimpolygleft={config[trimpolygleft]}         \
+        trimpolygright={config[trimpolygright]}       \
+        trimpolyg={config[trimpolyg]}                 \
+        filterpolyg={config[filterpolyg]}             \
+        entropy={config[entropy]}                     \
+        entropywindow={config[entropywindow]}         \
+        entropyk={config[entropyk]}                   \
+        minbasefrequency={config[minbasefrequency]}   \
+        entropytrim={config[entropytrim]}             \
+        entropymask={config[entropymask]}             \
+        entropymark={config[entropymark]}             \
+        cardinality={config[cardinality]}             \
+        cardinalityout={config[cardinalityout]}       \
+        loglogk={config[loglogk]}                     \
+        loglogbuckets={config[loglogbuckets]} 
 
-done
+    fns="$out $outm"
+    if [[ $paired -eq 1 ]]; then
+        fns="$fns $out2 $outm2"
+    fi
+    fns=$(echo "$fns" | tr ' ' '\n')
+    for fn in $fns ; do
+        pushd $(dirname $fn)
+        md5sum $fn > $fn.md5
+        popd
+    done
 
-pushd $TMPDIR/out
-fns=$(ls)
-for fn in $fns; do
-    md5sum $fn > $fn.md5
+    pushd $TMPDIR/report/$report
+    fns=$(ls)
+    for fn in $fns ; do
+        md5sum $fn > $fn.md5
+    done
+    popd
 done
-popd
-
-pushd $TMPDIR/report
-fns=$(ls)
-for fn in $fns; do
-    md5sum $fn > $fn.md5
-done
-popd
 
 d=$(dirname {snakemake.output.out_done})
 mkdir -p $d
-cp $TMPDIR/out/* $d
+cp -r $TMPDIR/out/* $d
 
 d=$(dirname {snakemake.output.report_done})
 mkdir -p $d
-cp $TMPDIR/report/* $d
+cp -r $TMPDIR/report/* $d
+
+d=$(dirname {snakemake.output.rejected_done})
+mkdir -p $d
+cp -r $TMPDIR/rejected/* $d
 
 touch {snakemake.output.out_done}
 touch {snakemake.output.report_done}
+touch {snakemake.output.rejected_done}
 
 """
 )

--- a/snappy_wrappers/wrappers/fastp/environment.yaml
+++ b/snappy_wrappers/wrappers/fastp/environment.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - fastp

--- a/snappy_wrappers/wrappers/fastp/run/environment.yaml
+++ b/snappy_wrappers/wrappers/fastp/run/environment.yaml
@@ -1,0 +1,1 @@
+../environment.yaml

--- a/snappy_wrappers/wrappers/fastp/run/wrapper.py
+++ b/snappy_wrappers/wrappers/fastp/run/wrapper.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""CUBI+Snakemake wrapper code for fastp: Snakemake wrapper.py
+"""
+
+from snakemake import shell
+
+__author__ = "Eric Blanc <eric.blanc@bih-charite.de>"
+
+shell.executable("/bin/bash")
+
+# Input fastqs are passed through snakemake.params.
+# snakemake.input is a .done file touched after linking files in.
+input_left = snakemake.params.args["input"]["reads_left"]
+input_right = snakemake.params.args["input"].get("reads_right", "")
+
+this_file = __file__
+
+this_step = snakemake.config["pipeline_step"]["name"]
+config = snakemake.config["step_config"][this_step]["fastp"]
+
+shell(
+    r"""
+set -x
+
+# TODO: remove this again, is for fail early
+# Additional logging for transparency & reproducibility
+# Logging: Save a copy this wrapper (with the pickle details in the header)
+cp {this_file} $(dirname {snakemake.log.log})/wrapper_bwa.py
+
+# Write out information about conda installation.
+conda list >{snakemake.log.conda_list}
+conda info >{snakemake.log.conda_info}
+md5sum {snakemake.log.conda_list} >{snakemake.log.conda_list_md5}
+md5sum {snakemake.log.conda_info} >{snakemake.log.conda_info_md5}
+
+# Also pipe stderr to log file
+if [[ -n "{snakemake.log.log}" ]]; then
+    if [[ "$(set +e; tty; set -e)" != "" ]]; then
+        rm -f "{snakemake.log.log}" && mkdir -p $(dirname {snakemake.log.log})
+        exec 2> >(tee -a "{snakemake.log.log}" >&2)
+    else
+        rm -f "{snakemake.log.log}" && mkdir -p $(dirname {snakemake.log.log})
+        echo "No tty, logging disabled" >"{snakemake.log.log}"
+    fi
+fi
+
+# Setup auto-cleaned TMPDIR
+export TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+mkdir -p $TMPDIR/out $TMPDIR/report
+
+# Define left and right reads as Bash arrays
+declare -a reads_left=({input_left})
+declare -a reads_right=({input_right})
+
+# Check whether we have paired reads
+if [[ ${{#reads_right[*]}} -eq 0 ]]; then
+    paired=0
+else
+    paired=1
+fi
+
+# Check that we either have single-ended reds
+if [[ $paired -eq 1 ]] && [[ ${{#reads_right[*]}} -ne ${{#reads_left[*]}} ]]; then
+    >&2 echo "Number of right and left reads must be the same but was"
+    >&2 echo "  left:  $reads_left"
+    >&2 echo "  right: $reads_right"
+    exit 1
+fi
+
+# Start fastp script
+
+for ((i = 0; i < ${{#reads_left[@]}}; i++)); do
+    # Find the base of filename (i.e. without fastq.gz (or derivatives) extension)
+    base=$(basename ${{reads_left[$i]}} | sed -e "s/\.f(ast)q(\.gz)?$//")
+    if [[ $paired -eq 1 ]]; then
+        # Common name between left & right reads (https://stackoverflow.com/questions/6973088/longest-common-prefix-of-two-strings-in-bash)
+        base=$(printf "%s\n%s\n" $(basename ${{reads_left[$i]}}) $(basename ${{reads_right[$i]}}) | sed -e 'N;s/^\(.*\).*\n\1.*$/\1/' | sed -e "s/_R$//")
+    fi
+
+    in=${{reads_left[$i]}}
+    out=$TMPDIR/out/$(basename $in)
+    unpaired=$TMPDIR/out/unpaired_$(basename $in)
+    failed=$TMPDIR/out/failed_$(basename $in)
+
+    if [[ $paired -eq 1 ]]; then
+        in2=${{reads_right[$i]}}
+        out2=$TMPDIR/out/$(basename $in2)
+        unpaired2=$TMPDIR/out/unpaired_$(basename $in2)
+    fi
+
+    
+    fastp \
+        --in1 $in --out1 $out --unpaired1 $unpaired \
+        $(if [[ $paired -eq 1 ]]; then \
+            echo --in2 $in2 --out2 $out2 --unpaired2 $unpaired2
+        fi) \
+        --failed_out $failed \
+        --json $TMPDIR/report/$base.json \
+        --html $TMPDIR/report/$base.html \
+        --thread {config[num_threads]} \
+        {config[parameters]}
+
+done
+
+pushd $TMPDIR/out
+fns=$(ls)
+for fn in $fns; do
+    md5sum $fn > $fn.md5
+done
+popd
+
+pushd $TMPDIR/report
+fns=$(ls)
+for fn in $fns; do
+    md5sum $fn > $fn.md5
+done
+popd
+
+d=$(dirname {snakemake.output.out_done})
+mkdir -p $d
+cp $TMPDIR/out/* $d
+
+d=$(dirname {snakemake.output.report_done})
+mkdir -p $d
+cp $TMPDIR/report/* $d
+
+touch {snakemake.output.out_done}
+touch {snakemake.output.report_done}
+
+"""
+)
+
+# Compute MD5 sums of logs.
+shell(
+    r"""
+md5sum {snakemake.log.log} >{snakemake.log.log_md5}
+"""
+)

--- a/snappy_wrappers/wrappers/fastp/run/wrapper.py
+++ b/snappy_wrappers/wrappers/fastp/run/wrapper.py
@@ -10,8 +10,33 @@ shell.executable("/bin/bash")
 
 # Input fastqs are passed through snakemake.params.
 # snakemake.input is a .done file touched after linking files in.
+library_name = snakemake.params.args["library_name"]
 input_left = snakemake.params.args["input"]["reads_left"]
-input_right = snakemake.params.args["input"].get("reads_right", "")
+input_right = (
+    snakemake.params.args["input"]["reads_right"]
+    if snakemake.params.args["input"]["reads_right"]
+    else {}
+)
+
+input_path_left = list(input_left.keys())
+prefix_left = [x["relative_path"] for x in input_left.values()]
+filename_left = [x["filename"] for x in input_left.values()]
+
+assert len(input_path_left) == len(prefix_left)
+assert len(input_path_left) == len(filename_left)
+
+if input_right:
+    input_path_right = list(input_right.keys())
+    prefix_right = [x["relative_path"] for x in input_right.values()]
+    filename_right = [x["filename"] for x in input_right.values()]
+
+    assert len(input_path_left) == len(input_path_right)
+    assert len(prefix_left) == len(prefix_right)
+    assert len(filename_left) == len(filename_right)
+else:
+    input_path_right = []
+    prefix_right = []
+    filename_right = []
 
 this_file = __file__
 
@@ -25,7 +50,7 @@ set -x
 # TODO: remove this again, is for fail early
 # Additional logging for transparency & reproducibility
 # Logging: Save a copy this wrapper (with the pickle details in the header)
-cp {this_file} $(dirname {snakemake.log.log})/wrapper_bwa.py
+cp {this_file} $(dirname {snakemake.log.log})/wrapper_fastp.py
 
 # Write out information about conda installation.
 conda list >{snakemake.log.conda_list}
@@ -50,8 +75,12 @@ trap "rm -rf $TMPDIR" EXIT
 mkdir -p $TMPDIR/out $TMPDIR/report
 
 # Define left and right reads as Bash arrays
-declare -a reads_left=({input_left})
-declare -a reads_right=({input_right})
+declare -a reads_left=({input_path_left})
+declare -a reads_right=({input_path_right})
+declare -a prefix_left=({prefix_left})
+declare -a prefix_right=({prefix_right})
+declare -a filename_left=({filename_left})
+declare -a filename_right=({filename_right})
 
 # Check whether we have paired reads
 if [[ ${{#reads_right[*]}} -eq 0 ]]; then
@@ -71,62 +100,138 @@ fi
 # Start fastp script
 
 for ((i = 0; i < ${{#reads_left[@]}}; i++)); do
-    # Find the base of filename (i.e. without fastq.gz (or derivatives) extension)
-    base=$(basename ${{reads_left[$i]}} | sed -e "s/\.f(ast)q(\.gz)?$//")
-    if [[ $paired -eq 1 ]]; then
-        # Common name between left & right reads (https://stackoverflow.com/questions/6973088/longest-common-prefix-of-two-strings-in-bash)
-        base=$(printf "%s\n%s\n" $(basename ${{reads_left[$i]}}) $(basename ${{reads_right[$i]}}) | sed -e 'N;s/^\(.*\).*\n\1.*$/\1/' | sed -e "s/_R$//")
-    fi
-
     in=${{reads_left[$i]}}
-    out=$TMPDIR/out/$(basename $in)
-    unpaired=$TMPDIR/out/unpaired_$(basename $in)
-    failed=$TMPDIR/out/failed_$(basename $in)
+    out=$TMPDIR/out/${{prefix_left[$i]}}/${{filename_left[$i]}}
+    unpaired=$TMPDIR/rejected/${{prefix_left[$i]}}/${{filename_left[$i]}}
+    failed=$TMPDIR/rejected/${{prefix_left[$i]}}/failed_${{filename_left[$i]}}
+    mkdir -p $(dirname $out) $(dirname $unpaired)
 
     if [[ $paired -eq 1 ]]; then
         in2=${{reads_right[$i]}}
-        out2=$TMPDIR/out/$(basename $in2)
-        unpaired2=$TMPDIR/out/unpaired_$(basename $in2)
+        out2=$TMPDIR/out/${{prefix_right[$i]}}/${{filename_right[$i]}}
+        unpaired2=$TMPDIR/rejected/${{prefix_right[$i]}}/${{filename_right[$i]}}
+        mkdir -p $(dirname $out2) $(dirname $unpaired2)
     fi
 
-    
+    # Find the base of filename (i.e. without fastq.gz (or derivatives) extension)
+    report="${{prefix_left[$i]}}/${{filename_left[$i]}}"
+    if [[ $paired -eq 1 ]]; then
+        report="${{report}}_${{filename_right[$i]}}"
+    fi
+    mkdir -p $TMPDIR/report/$report
+
     fastp \
         --in1 $in --out1 $out --unpaired1 $unpaired \
         $(if [[ $paired -eq 1 ]]; then \
             echo --in2 $in2 --out2 $out2 --unpaired2 $unpaired2
         fi) \
         --failed_out $failed \
-        --json $TMPDIR/report/$base.json \
-        --html $TMPDIR/report/$base.html \
+        --json $TMPDIR/report/$report/report.json \
+        --html $TMPDIR/report/$report/report.html \
         --thread {config[num_threads]} \
-        {config[parameters]}
+        --trim_front1 {config[trim_front1]}                                 \
+        --trim_tail1 {config[trim_tail1]}                                   \
+        --max_len1 {config[max_len1]}                                       \
+        --trim_front2 {config[trim_front2]}                                 \
+        --trim_tail2 {config[trim_tail2]}                                   \
+        --max_len2 {config[max_len2]}                                       \
+        $(if [[ "{config[dedup]}" = "True" ]]; then \
+            echo --dedup --dup_calc_accuracy {config[dup_calc_accuracy]}
+        else \
+            echo --dont_eval_duplication
+        fi) \
+        $(if [[ "{config[trim_poly_g]}" = "True" ]]; then \
+            echo --trim_poly_g --poly_g_min_len {config[poly_g_min_len]}
+        else \
+            echo --disable_trim_poly_g
+        fi) \
+        $(if [[ "{config[trim_poly_x]}" = "True" ]]; then \
+            echo --trim_poly_x --poly_x_min_len {config[poly_x_min_len]}
+        fi) \
+        $(if [[ "{config[cut_front]}" = "True" ]]; then \
+            echo --cut_front --cut_front_window_size {config[cut_front_window_size]} --cut_front_mean_quality {config[cut_front_mean_quality]}
+        fi) \
+        $(if [[ "{config[cut_tail]}" = "True" ]]; then \
+            echo --cut_tail --cut_tail_window_size {config[cut_tail_window_size]} --cut_tail_mean_quality {config[cut_tail_mean_quality]}
+        fi) \
+        $(if [[ "{config[cut_right]}" = "True" ]]; then \
+            echo --cut_right --cut_right_window_size {config[cut_right_window_size]} --cut_right_mean_quality {config[cut_right_mean_quality]}
+        fi) \
+        $(if [[ "{config[disable_quality_filtering]}" = "False" ]]; then \
+            echo --qualified_quality_phred {config[qualified_quality_phred]}
+            echo --unqualified_percent_limit {config[unqualified_percent_limit]}
+            echo --n_base_limit {config[n_base_limit]}
+            echo --average_qual {config[average_qual]}
+        else \
+            echo --disable_quality_filtering
+        fi) \
+        $(if [[ "{config[disable_length_filtering]}" = "False" ]]; then \
+            echo --length_required {config[length_required]}
+            echo --length_limit {config[length_limit]}
+        else \
+            echo --disable_length_filtering
+        fi) \
+        $(if [[ "{config[low_complexity_filter]}" = "True" ]]; then \
+            echo --low_complexity_filter --complexity_threshold {config[complexity_threshold]}
+        fi) \
+        $(if [[ -n "{config[filter_by_index1]}" ]]; then \
+            echo --filter_by_index1 {config[filter_by_index1]} --filter_by_index_threshold {config[filter_by_index_threshold]}
+        fi) \
+        $(if [[ -n "{config[filter_by_index2]}" ]]; then \
+            echo --filter_by_index2 {config[filter_by_index2]} --filter_by_index_threshold {config[filter_by_index_threshold]}
+        fi) \
+        $(if [[ "{config[correction]}" = "True" ]]; then \
+            echo --correction
+            echo --overlap_len_require {config[overlap_len_require]}
+            echo --overlap_diff_limit {config[overlap_diff_limit]}
+            echo --overlap_diff_percent_limit {config[overlap_diff_percent_limit]}
+        fi) \
+        $(if [[ "{config[umi]}" = "True" ]]; then \
+            echo --umi
+            echo --umi_loc {config[umi_loc]}
+            echo --umi_len {config[umi_len]}
+            echo --umi_prefix {config[umi_prefix]}
+            echo --umi_skip {config[umi_skip]}
+        fi) \
+        $(if [[ "{config[overrepresentation_analysis]}" = "True" ]]; then \
+            echo --overrepresentation_analysis
+        fi)
+
+    fns="$out $unpaired $failed"
+    if [[ $paired -eq 1 ]]; then
+        fns="$fns $out2 $unpaired2"
+    fi
+    fns=$(echo "$fns" | tr ' ' '\n')
+    for fn in $fns ; do
+        pushd $(dirname $fn)
+        md5sum $fn > $fn.md5
+        popd
+    done
+
+    pushd $TMPDIR/report/$report
+    fns=$(ls)
+    for fn in $fns ; do
+        md5sum $fn > $fn.md5
+    done
+    popd
 
 done
-
-pushd $TMPDIR/out
-fns=$(ls)
-for fn in $fns; do
-    md5sum $fn > $fn.md5
-done
-popd
-
-pushd $TMPDIR/report
-fns=$(ls)
-for fn in $fns; do
-    md5sum $fn > $fn.md5
-done
-popd
 
 d=$(dirname {snakemake.output.out_done})
 mkdir -p $d
-cp $TMPDIR/out/* $d
+cp -r $TMPDIR/out/* $d
 
 d=$(dirname {snakemake.output.report_done})
 mkdir -p $d
-cp $TMPDIR/report/* $d
+cp -r $TMPDIR/report/* $d
+
+d=$(dirname {snakemake.output.rejected_done})
+mkdir -p $d
+cp -r $TMPDIR/rejected/* $d
 
 touch {snakemake.output.out_done}
 touch {snakemake.output.report_done}
+touch {snakemake.output.rejected_done}
 
 """
 )

--- a/tests/snappy_pipeline/workflows/conftest.py
+++ b/tests/snappy_pipeline/workflows/conftest.py
@@ -590,14 +590,13 @@ def cancer_sheet_tsv():
     return textwrap.dedent(
         """
         patientName\tsampleName\tisTumor\tlibraryType\tfolderName
-        P001\tN1\tN\tWGS\tP001-N1-DNA1-WGS1
-        P001\tT1\tY\tWGS\tP001-T1-DNA1-WGS1
-        P001\tT1\tY\tmRNA_seq\tP001-T1-RNA1-mRNAseq1
-        P002\tN1\tN\tWGS\tP002-N1-DNA1-WGS1
-        P002\tT1\tY\tWGS\tP002-T1-DNA1-WGS1
-        P002\tT1\tY\tWGS\tP002-T1-DNA1-WGS2
-        P002\tT2\tY\tWGS\tP002-T2-DNA1-WGS1
-        P002\tT2\tY\tmRNA_seq\tP002-T2-RNA1-mRNAseq1
+        P001\tN1\tN\tWGS\tP001_N1_DNA1_WGS1
+        P001\tT1\tY\tWGS\tP001_T1_DNA1_WGS1
+        P001\tT1\tY\tmRNA_seq\tP001_T1_RNA1_mRNA_seq1
+        P002\tN1\tN\tWGS\tP002_N1_DNA1_WGS1
+        P002\tT1\tY\tWGS\tP002_T1_DNA1_WGS1
+        P002\tT2\tY\tWGS\tP002_T2_DNA1_WGS1
+        P002\tT2\tY\tmRNA_seq\tP002_T12RNA1_mRNA_seq1
         """
     ).lstrip()
 
@@ -777,8 +776,32 @@ def cancer_sheet_fake_fs(fake_fs, cancer_sheet_tsv):
     tpl = "/path/{folder}/FCXXXXXX/L001/{folder}_R{i}.fastq.gz"
     for line in cancer_sheet_tsv.splitlines()[1:]:
         folder = line.split("\t")[4]
-        fake_fs.fs.create_file(tpl.format(folder=folder, i=1))
-        fake_fs.fs.create_file(tpl.format(folder=folder, i=2))
+        fake_fs.fs.create_file(tpl.format(folder=folder, i=1), create_missing_dirs=True)
+        fake_fs.fs.create_file(tpl.format(folder=folder, i=2), create_missing_dirs=True)
+    # Create the sample TSV file
+    fake_fs.fs.create_file(
+        "/work/config/sheet.tsv", contents=cancer_sheet_tsv, create_missing_dirs=True
+    )
+    return fake_fs
+
+
+@pytest.fixture
+def cancer_sheet_fake_fs_path_link_in(fake_fs, cancer_sheet_tsv):
+    """Return fake file system setup with files for the cancer_sheet_tsv"""
+    # Create work directory
+    fake_fs.fs.makedirs("/work", exist_ok=True)
+    # Create FASTQ read files for the samples
+    tpl = "/preprocess/{library_name}/FCXXXXXX/L001/out/{donor}_R{i}.fastq.gz"
+    for line in cancer_sheet_tsv.splitlines()[1:]:
+        (donor, sample, isTumor, assay, folder) = line.split("\t")
+        extract = "RNA" if assay == "mRNA_seq" else "DNA"
+        library_name = f"{donor}-{sample}-{extract}1-{assay}1"
+        fake_fs.fs.create_file(
+            tpl.format(donor=donor, library_name=library_name, i=1), create_missing_dirs=True
+        )
+        fake_fs.fs.create_file(
+            tpl.format(donor=donor, library_name=library_name, i=2), create_missing_dirs=True
+        )
     # Create the sample TSV file
     fake_fs.fs.create_file(
         "/work/config/sheet.tsv", contents=cancer_sheet_tsv, create_missing_dirs=True

--- a/tests/snappy_pipeline/workflows/conftest.py
+++ b/tests/snappy_pipeline/workflows/conftest.py
@@ -709,7 +709,7 @@ def germline_sheet_fake_fs_path_link_in(fake_fs, germline_sheet_tsv):
     # Create work directory
     fake_fs.fs.makedirs("/work", exist_ok=True)
     # Create FASTQ read files for the samples
-    tpl = "/preprocess/{donor}-N1-DNA1-WGS1/FCXXXXXX/L001/{donor}_R{i}.fastq.gz"
+    tpl = "/preprocess/{donor}-N1-DNA1-WGS1/FCXXXXXX/L001/out/{donor}_R{i}.fastq.gz"
     for line in germline_sheet_tsv.splitlines()[1:]:
         donor = line.split("\t")[0]
         # Create fastq files

--- a/tests/snappy_pipeline/workflows/conftest.py
+++ b/tests/snappy_pipeline/workflows/conftest.py
@@ -704,6 +704,30 @@ def germline_sheet_fake_fs(fake_fs, germline_sheet_tsv):
 
 
 @pytest.fixture
+def germline_sheet_fake_fs_path_link_in(fake_fs, germline_sheet_tsv):
+    """Return fake file system setup with files for the germline_sheet_tsv"""
+    # Create work directory
+    fake_fs.fs.makedirs("/work", exist_ok=True)
+    # Create FASTQ read files for the samples
+    tpl = "/preprocess/{donor}-N1-DNA1-WGS1/FCXXXXXX/L001/{donor}_R{i}.fastq.gz"
+    for line in germline_sheet_tsv.splitlines()[1:]:
+        donor = line.split("\t")[0]
+        # Create fastq files
+        fake_fs.fs.create_file(tpl.format(donor=donor, i=1), create_missing_dirs=True)
+        fake_fs.fs.create_file(tpl.format(donor=donor, i=2), create_missing_dirs=True)
+        # Create md5 files
+        md5_r1 = tpl.format(donor=donor, i=1) + ".md5"
+        fake_fs.fs.create_file(md5_r1, create_missing_dirs=True)
+        md5_r2 = tpl.format(donor=donor, i=2) + ".md5"
+        fake_fs.fs.create_file(md5_r2, create_missing_dirs=True)
+    # Create the sample TSV file
+    fake_fs.fs.create_file(
+        "/work/config/sheet.tsv", contents=germline_sheet_tsv, create_missing_dirs=True
+    )
+    return fake_fs
+
+
+@pytest.fixture
 def germline_sheet_fake_fs2(
     fake_fs2, germline_sheet_tsv, tsv_large_cohort_trios_only_germline_sheet
 ):

--- a/tests/snappy_pipeline/workflows/test_workflows_abstract.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_abstract.py
@@ -180,6 +180,7 @@ def dummy_generic_step(
                 r"""
                 step_config:
                   dummy:
+                    path_link_in: ""
                     key: value
                 """
             ).lstrip()

--- a/tests/snappy_pipeline/workflows/test_workflows_abstract.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_abstract.py
@@ -4,9 +4,9 @@
 
 import textwrap
 
-from biomedsheets.shortcuts import GenericSampleSheet
 import pytest
 import ruamel.yaml as ruamel_yaml
+from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import Wildcards
 
 from snappy_pipeline.base import MissingConfiguration

--- a/tests/snappy_pipeline/workflows/test_workflows_abstract.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_abstract.py
@@ -149,10 +149,26 @@ def test_link_in_path_generator_path_link_in(
     )
     # Check results
     expected = [
-        ("/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R1.fastq.gz"),
-        ("/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R2.fastq.gz"),
-        ("/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R1.fastq.gz.md5"),
-        ("/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R2.fastq.gz.md5"),
+        (
+            "/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out",
+            "FCXXXXXX/L001/out",
+            "P001_R1.fastq.gz",
+        ),
+        (
+            "/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out",
+            "FCXXXXXX/L001/out",
+            "P001_R2.fastq.gz",
+        ),
+        (
+            "/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out",
+            "FCXXXXXX/L001/out",
+            "P001_R1.fastq.gz.md5",
+        ),
+        (
+            "/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out",
+            "FCXXXXXX/L001/out",
+            "P001_R2.fastq.gz.md5",
+        ),
     ]
     assert list(generator.run("P001-N1-DNA1-WGS1")) == expected
 
@@ -324,10 +340,10 @@ def test_link_in_step_part_get_shell_cmd_path_link_in(
     # Check results
     expected = textwrap.dedent(
         r"""
-        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
-        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
-        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz.md5 || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
-        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz.md5 || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz.md5 || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz.md5 || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out; }}
         """
     ).strip()
     assert actual == expected

--- a/tests/snappy_pipeline/workflows/test_workflows_abstract.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_abstract.py
@@ -123,6 +123,40 @@ def test_link_in_path_generator(germline_sheet_fake_fs, config_lookup_paths, wor
     assert list(generator.run("P001")) == expected
 
 
+def test_link_in_path_generator_path_link_in(
+    germline_sheet_fake_fs_path_link_in, config_lookup_paths, work_dir, mocker
+):
+    # Patch out the file system related things in the abstract workflow module
+    patch_module_fs(
+        "snappy_pipeline.workflows.abstract", germline_sheet_fake_fs_path_link_in, mocker
+    )
+    # Exercise the code under test
+    info = DataSetInfo(
+        "first_batch",
+        "sheet.tsv",
+        config_lookup_paths,
+        ["/path"],
+        [{"left": "*/*/*_R1.fastq.gz", "right": "*/*/*_R2.fastq.gz"}],
+        "germline_variants",
+        False,
+        "secondary_id_pk",
+        False,
+        None,
+        None,
+    )
+    generator = LinkInPathGenerator(
+        work_dir, [info], [], cache_file_name="_cache_file", preprocessed_path="/preprocess"
+    )
+    # Check results
+    expected = [
+        ("/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R1.fastq.gz"),
+        ("/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R2.fastq.gz"),
+        ("/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R1.fastq.gz.md5"),
+        ("/preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001", "FCXXXXXX/L001", "P001_R2.fastq.gz.md5"),
+    ]
+    assert list(generator.run("P001-N1-DNA1-WGS1")) == expected
+
+
 # Test LinkInStep ------------------------------------------------------------------------
 
 
@@ -195,6 +229,54 @@ def dummy_generic_step(
     )
 
 
+@pytest.fixture
+def dummy_generic_step_path_link_in(
+    dummy_workflow,
+    dummy_config,
+    config_lookup_paths,
+    config_paths,
+    work_dir,
+    germline_sheet_fake_fs_path_link_in,
+    mocker,
+):
+    """Return BaseStep sub class instance using generic sample sheets; for use in tests of the
+    abstract workflow module
+    """
+
+    class DummyBaseStep(BaseStep):
+        """Dummy BaseStep sub class; for use in tests"""
+
+        name = "dummy"
+        sheet_shortcut_class = GenericSampleSheet
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.register_sub_step_classes((LinkInStep, LinkOutStepPart))
+
+        @classmethod
+        def default_config_yaml(cls):
+            """Return default config YAML"""
+            return textwrap.dedent(
+                r"""
+                step_config:
+                  dummy:
+                    path_link_in: "/preprocess"
+                    key: value
+                """
+            ).lstrip()
+
+    patch_module_fs(
+        "snappy_pipeline.workflows.abstract", germline_sheet_fake_fs_path_link_in, mocker
+    )
+    return DummyBaseStep(
+        dummy_workflow,
+        dummy_config,
+        config_lookup_paths,
+        config_paths,
+        work_dir,
+    )
+
+
 def test_link_in_step_part_get_input_files(dummy_generic_step):
     assert dummy_generic_step.get_input_files("link_in", "run") == []
 
@@ -220,6 +302,32 @@ def test_link_in_step_part_get_shell_cmd(
         mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz || ln -sr /path/P001/FCXXXXXX/L001/P001_R2.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
         mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz.md5 || ln -sr /path/P001/FCXXXXXX/L001/P001_R1.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
         mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz.md5 || ln -sr /path/P001/FCXXXXXX/L001/P001_R2.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
+        """
+    ).strip()
+    assert actual == expected
+
+
+def test_link_in_step_part_get_shell_cmd_path_link_in(
+    germline_sheet_fake_fs_path_link_in,
+    config_lookup_paths,
+    work_dir,
+    mocker,
+    dummy_generic_step_path_link_in,
+):
+    # Patch out file system--related stuff in abstract workflow
+    patch_module_fs(
+        "snappy_pipeline.workflows.abstract", germline_sheet_fake_fs_path_link_in, mocker
+    )
+    # Exercise code under test
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    actual = dummy_generic_step_path_link_in.get_shell_cmd("link_in", "run", wildcards)
+    # Check results
+    expected = textwrap.dedent(
+        r"""
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz.md5 || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R1.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
+        mkdir -p work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001 && {{ test -h work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz.md5 || ln -sr /preprocess/P001-N1-DNA1-WGS1/FCXXXXXX/L001/P001_R2.fastq.gz.md5 work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001; }}
         """
     ).strip()
     assert actual == expected

--- a/tests/snappy_pipeline/workflows/test_workflows_abstract.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_abstract.py
@@ -4,9 +4,9 @@
 
 import textwrap
 
+from biomedsheets.shortcuts import GenericSampleSheet
 import pytest
 import ruamel.yaml as ruamel_yaml
-from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import Wildcards
 
 from snappy_pipeline.base import MissingConfiguration

--- a/tests/snappy_pipeline/workflows/test_workflows_adapter_trimming.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_adapter_trimming.py
@@ -122,15 +122,15 @@ def test_bbduk_step_part_get_args_input(adapter_trimming_workflow):
         "library_name": "P001-T1-DNA1-WGS1",
         "input": {
             "reads_left": {
-                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R1.fastq.gz": {
+                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001_T1_DNA1_WGS1_R1.fastq.gz": {
                     "relative_path": "FCXXXXXX/L001",
-                    "filename": "P001-T1-DNA1-WGS1_R1.fastq.gz",
+                    "filename": "P001_T1_DNA1_WGS1_R1.fastq.gz",
                 },
             },
             "reads_right": {
-                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R2.fastq.gz": {
+                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001_T1_DNA1_WGS1_R2.fastq.gz": {
                     "relative_path": "FCXXXXXX/L001",
-                    "filename": "P001-T1-DNA1-WGS1_R2.fastq.gz",
+                    "filename": "P001_T1_DNA1_WGS1_R2.fastq.gz",
                 },
             },
         },
@@ -195,15 +195,15 @@ def test_fastp_step_part_get_args_input(adapter_trimming_workflow):
         "library_name": "P001-T1-DNA1-WGS1",
         "input": {
             "reads_left": {
-                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R1.fastq.gz": {
+                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001_T1_DNA1_WGS1_R1.fastq.gz": {
                     "relative_path": "FCXXXXXX/L001",
-                    "filename": "P001-T1-DNA1-WGS1_R1.fastq.gz",
+                    "filename": "P001_T1_DNA1_WGS1_R1.fastq.gz",
                 },
             },
             "reads_right": {
-                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R2.fastq.gz": {
+                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001_T1_DNA1_WGS1_R2.fastq.gz": {
                     "relative_path": "FCXXXXXX/L001",
-                    "filename": "P001-T1-DNA1-WGS1_R2.fastq.gz",
+                    "filename": "P001_T1_DNA1_WGS1_R2.fastq.gz",
                 },
             },
         },
@@ -251,7 +251,6 @@ def test_adapter_trimming_workflow_get_results(adapter_trimming_workflow):
         "P001-T1-RNA1-mRNA_seq1",
         "P002-N1-DNA1-WGS1",
         "P002-T1-DNA1-WGS1",
-        "P002-T1-DNA1-WGS2",
         "P002-T2-DNA1-WGS1",
         "P002-T2-RNA1-mRNA_seq1",
     )

--- a/tests/snappy_pipeline/workflows/test_workflows_adapter_trimming.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_adapter_trimming.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""Tests for the hla_typing workflow module code"""
+
+import textwrap
+
+import pytest
+import ruamel.yaml as ruamel_yaml
+from snakemake.io import Wildcards
+
+from snappy_pipeline.workflows.adapter_trimming import AdapterTrimmingWorkflow
+
+from .conftest import patch_module_fs
+
+__author__ = "Eric Blanc <eric.blanc@bih-charite.de>"
+
+
+@pytest.fixture(scope="module")  # otherwise: performance issues
+def minimal_config():
+    """Return YAML parsing result for (germline) configuration"""
+    yaml = ruamel_yaml.YAML()
+    return yaml.load(
+        textwrap.dedent(
+            r"""
+        static_data_config:
+          reference:
+            path: /path/to/ref.fa
+
+        data_sets:
+          first_batch:
+            file: sheet.tsv
+            search_patterns:
+            - {'left': '*/*/*_R1.fastq.gz', 'right': '*/*/*_R2.fastq.gz'}
+            search_paths: ['/path']
+            type: matched_cancer
+            naming_scheme: only_secondary_id
+        """
+        ).lstrip()
+    )
+
+
+@pytest.fixture
+def adapter_trimming_workflow(
+    dummy_workflow,
+    minimal_config,
+    config_lookup_paths,
+    work_dir,
+    config_paths,
+    cancer_sheet_fake_fs,
+    mocker,
+):
+    """Return AdapterTrimmingWorkflow object pre-configured with cancer sheet"""
+    # Patch out file-system related things in abstract (the crawling link in step is defined there)
+    patch_module_fs("snappy_pipeline.workflows.abstract", cancer_sheet_fake_fs, mocker)
+    # Construct the workflow object
+    return AdapterTrimmingWorkflow(
+        dummy_workflow,
+        minimal_config,
+        config_lookup_paths,
+        config_paths,
+        work_dir,
+    )
+
+
+# Tests for BbdukStepPart ----------------------------------------------------------------------
+
+
+def test_bbduk_step_part_get_input_files(adapter_trimming_workflow):
+    """Tests BBdukStepPart.get_input_files()"""
+    expected = {"done": "work/input_links/{library_name}/.done"}
+    actual = adapter_trimming_workflow.get_input_files("bbduk", "run")
+    assert actual == expected
+
+
+def test_bbduk_step_part_get_output_files(adapter_trimming_workflow):
+    """Tests BbdukStepPart.get_output_files()"""
+    expected = {
+        "out_done": "work/bbduk.{library_name}/out/.done",
+        "report_done": "work/bbduk.{library_name}/report/.done",
+    }
+    actual = adapter_trimming_workflow.get_output_files("bbduk", "run")
+    assert actual == expected
+
+
+def test_bbduk_step_part_get_args_input(adapter_trimming_workflow):
+    wildcards = Wildcards(fromdict={"library_name": "P001-T1-DNA1-WGS1"})
+    sinput = adapter_trimming_workflow.substep_dispatch("bbduk", "get_args", "run")(wildcards)
+    assert sinput["input"]["reads_left"] == [
+        "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R1.fastq.gz"
+    ]
+    assert sinput["input"]["reads_right"] == [
+        "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R2.fastq.gz"
+    ]
+
+
+def test_bbduk_step_part_get_log_file(adapter_trimming_workflow):
+    """Tests BbdukStepPart.get_log_file()"""
+    expected = {
+        "done": "work/bbduk.{library_name}/log/.done",
+        "done_md5": "work/bbduk.{library_name}/log/.done.md5",
+    }
+    key_ext = (
+        ("log", ".log"),
+        ("conda_info", ".conda_info.txt"),
+        ("conda_list", ".conda_list.txt"),
+    )
+    for key, ext in key_ext:
+        expected[key] = "work/bbduk.{library_name}/log/bbduk.{library_name}" + ext
+        expected[key + "_md5"] = "work/bbduk.{library_name}/log/bbduk.{library_name}" + ext + ".md5"
+    actual = adapter_trimming_workflow.get_log_file("bbduk", "run")
+    assert actual == expected
+
+
+def test_bbduk_step_part_get_resource_usage(adapter_trimming_workflow):
+    """Tests BbdukStepPart.get_resource_usage()"""
+    # Define expected
+    expected_dict = {"threads": 8, "time": "12:00:00", "memory": "24000M", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = adapter_trimming_workflow.get_resource("bbduk", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for FastpStepPart ----------------------------------------------------------------------
+
+
+def test_fastp_step_part_get_input_files(adapter_trimming_workflow):
+    """Tests FastpStepPart.get_input_files()"""
+    expected = {"done": "work/input_links/{library_name}/.done"}
+    actual = adapter_trimming_workflow.get_input_files("fastp", "run")
+    assert actual == expected
+
+
+def test_fastp_step_part_get_output_files(adapter_trimming_workflow):
+    """Tests FastpStepPart.get_output_files()"""
+    expected = {
+        "out_done": "work/fastp.{library_name}/out/.done",
+        "report_done": "work/fastp.{library_name}/report/.done",
+    }
+    actual = adapter_trimming_workflow.get_output_files("fastp", "run")
+    assert actual == expected
+
+
+def test_fastp_step_part_get_args_input(adapter_trimming_workflow):
+    wildcards = Wildcards(fromdict={"library_name": "P001-T1-DNA1-WGS1"})
+    sinput = adapter_trimming_workflow.substep_dispatch("fastp", "get_args", "run")(wildcards)
+    assert sinput["input"]["reads_left"] == [
+        "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R1.fastq.gz"
+    ]
+    assert sinput["input"]["reads_right"] == [
+        "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R2.fastq.gz"
+    ]
+
+
+def test_fastp_step_part_get_log_file(adapter_trimming_workflow):
+    """Tests FastpStepPart.get_log_file()"""
+    expected = {
+        "done": "work/fastp.{library_name}/log/.done",
+        "done_md5": "work/fastp.{library_name}/log/.done.md5",
+    }
+    key_ext = (
+        ("log", ".log"),
+        ("conda_info", ".conda_info.txt"),
+        ("conda_list", ".conda_list.txt"),
+    )
+    for key, ext in key_ext:
+        expected[key] = "work/fastp.{library_name}/log/fastp.{library_name}" + ext
+        expected[key + "_md5"] = "work/fastp.{library_name}/log/fastp.{library_name}" + ext + ".md5"
+    actual = adapter_trimming_workflow.get_log_file("fastp", "run")
+    assert actual == expected
+
+
+def test_fastp_step_part_get_resource_usage(adapter_trimming_workflow):
+    """Tests FastpStepPart.get_resource_usage()"""
+    # Define expected
+    expected_dict = {"threads": 4, "time": "12:00:00", "memory": "24000M", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = adapter_trimming_workflow.get_resource("fastp", "run", resource)
+        assert actual == expected, msg_error

--- a/tests/snappy_pipeline/workflows/test_workflows_adapter_trimming.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_adapter_trimming.py
@@ -85,9 +85,9 @@ def test_link_out_fastq_step_part_get_shell_cmd(adapter_trimming_workflow):
     wildcards = Wildcards(fromdict={"trimmer": "bbduk", "library_name": "P001-N1-DNA1-WGS1"})
     expected = textwrap.dedent(
         r"""
-        din_=$(dirname work/bbduk.P001-N1-DNA1-WGS1/log/.done) ; dout=$(dirname output/bbduk/P001-N1-DNA1-WGS1/log/.done) ; fns=$(find $din_ -type f -printf '%P\n') ; for fn in $fns ; do if [[ ! -L $din_/$fn ]] ; then mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn ; fi ; done
-        din_=$(dirname work/bbduk.P001-N1-DNA1-WGS1/report/.done) ; dout=$(dirname output/bbduk/P001-N1-DNA1-WGS1/report/.done) ; fns=$(find $din_ -type f -printf '%P\n') ; for fn in $fns ; do if [[ ! -L $din_/$fn ]] ; then mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn ; fi ; done
-        din_=$(dirname work/bbduk.P001-N1-DNA1-WGS1/out/.done) ; dout=$(dirname output/bbduk/P001-N1-DNA1-WGS1/out/.done) ; fns=$(find $din_ -type f -printf '%P\n') ; for fn in $fns ; do if [[ ! -L $din_/$fn ]] ; then mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn ; fi ; done
+        din_=$(dirname work/bbduk.P001-N1-DNA1-WGS1/log/.done) ; dout=$(dirname output/bbduk/P001-N1-DNA1-WGS1/log/.done) ; fns=$(find $din_ -type f -printf '%P\n') ; for fn in $fns ; do     if [[ ! -L $din_/$fn ]] ; then       mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn   ; fi ; done
+        din_=$(dirname work/bbduk.P001-N1-DNA1-WGS1/report/.done) ; dout=$(dirname output/bbduk/P001-N1-DNA1-WGS1/report/.done) ; fns=$(find $din_ -type f -printf '%P\n') ; for fn in $fns ; do     if [[ ! -L $din_/$fn ]] ; then       mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn   ; fi ; done
+        din_=$(dirname work/bbduk.P001-N1-DNA1-WGS1/out/.done) ; dout=$(dirname output/bbduk/P001-N1-DNA1-WGS1/out/.done) ; fns=$(find $din_ -type f -printf '%P\n') ; for fn in $fns ; do     if [[ ! -L $din_/$fn ]] ; then       mkdir -p $(dirname $dout/$fn) ; ln -sr $din_/$fn $dout/$fn   ; fi ; done
         """
     ).strip()
     actual = adapter_trimming_workflow.get_shell_cmd("link_out_fastq", "run", wildcards)

--- a/tests/snappy_pipeline/workflows/test_workflows_adapter_trimming.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_adapter_trimming.py
@@ -121,18 +121,18 @@ def test_bbduk_step_part_get_args_input(adapter_trimming_workflow):
     expected = {
         "library_name": "P001-T1-DNA1-WGS1",
         "input": {
-            "reads_left": [
-                (
-                    "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R1.fastq.gz",
-                    {"relative_path": "FCXXXXXX/L001", "filename": "P001-T1-DNA1-WGS1_R1.fastq.gz"},
-                )
-            ],
-            "reads_right": [
-                (
-                    "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R2.fastq.gz",
-                    {"relative_path": "FCXXXXXX/L001", "filename": "P001-T1-DNA1-WGS1_R2.fastq.gz"},
-                )
-            ],
+            "reads_left": {
+                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R1.fastq.gz": {
+                    "relative_path": "FCXXXXXX/L001",
+                    "filename": "P001-T1-DNA1-WGS1_R1.fastq.gz",
+                },
+            },
+            "reads_right": {
+                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R2.fastq.gz": {
+                    "relative_path": "FCXXXXXX/L001",
+                    "filename": "P001-T1-DNA1-WGS1_R2.fastq.gz",
+                },
+            },
         },
     }
     assert actual == expected
@@ -194,18 +194,18 @@ def test_fastp_step_part_get_args_input(adapter_trimming_workflow):
     expected = {
         "library_name": "P001-T1-DNA1-WGS1",
         "input": {
-            "reads_left": [
-                (
-                    "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R1.fastq.gz",
-                    {"relative_path": "FCXXXXXX/L001", "filename": "P001-T1-DNA1-WGS1_R1.fastq.gz"},
-                )
-            ],
-            "reads_right": [
-                (
-                    "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R2.fastq.gz",
-                    {"relative_path": "FCXXXXXX/L001", "filename": "P001-T1-DNA1-WGS1_R2.fastq.gz"},
-                )
-            ],
+            "reads_left": {
+                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R1.fastq.gz": {
+                    "relative_path": "FCXXXXXX/L001",
+                    "filename": "P001-T1-DNA1-WGS1_R1.fastq.gz",
+                },
+            },
+            "reads_right": {
+                "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001-T1-DNA1-WGS1_R2.fastq.gz": {
+                    "relative_path": "FCXXXXXX/L001",
+                    "filename": "P001-T1-DNA1-WGS1_R2.fastq.gz",
+                },
+            },
         },
     }
     assert actual == expected

--- a/tests/snappy_pipeline/workflows/test_workflows_cbioportal_export.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_cbioportal_export.py
@@ -52,10 +52,10 @@ def minimal_config():
 
         cbioportal_export:
           # Paths to snappy steps containing results to be uploaded
-          path_ngs_mapping: ../NGS_MAPPING
-          path_gene_expression_quantification: ../GENE_EXP_QUANTIFICATION
-          path_somatic_variant_filtration: ../SOM_VAR_FILTRATION
-          path_copy_number_step: ../SOM_CNV_CALLING
+          path_ngs_mapping: /NGS_MAPPING
+          path_gene_expression_quantification: /GENE_EXP_QUANTIFICATION
+          path_somatic_variant_filtration: /SOM_VAR_FILTRATION
+          path_copy_number_step: /SOM_CNV_CALLING
           # Select tools & filter set
           cnv_tool: control_freec
           tools_somatic_variant_calling: [ "mutect2" ]
@@ -388,10 +388,10 @@ def test_cbioportal_cna_data_step_part_get_input_files_log2(cbioportal_export_wo
     """Tests cbioportalCnaFilesStepPart.get_input_files() - action 'log2'"""
     # Define expected
     base_name = (
-        "SOM_CNV_CALLING/output/bwa.copywriter.P00{i}-T{t}-DNA1-WGS{g}/out/"
-        "bwa.copywriter.P00{i}-T{t}-DNA1-WGS{g}_gene_log2.txt"
+        "SOM_CNV_CALLING/output/bwa.copywriter.P00{i}-T{t}-DNA1-WGS1/out/"
+        "bwa.copywriter.P00{i}-T{t}-DNA1-WGS1_gene_log2.txt"
     )
-    expected = [base_name.format(i=i, t=t, g=g) for i, t, g in ((1, 1, 1), (2, 1, 2), (2, 2, 1))]
+    expected = [base_name.format(i=i, t=t) for i, t in ((1, 1), (2, 1), (2, 2))]
     # Get actual
     actual = cbioportal_export_workflow.get_input_files("cbioportal_cna_data", "log2")
     assert actual == expected
@@ -401,10 +401,10 @@ def test_cbioportal_cna_data_step_part_get_input_files_gistic(cbioportal_export_
     """Tests cbioportalCnaFilesStepPart.get_input_files() - action 'gistic'"""
     # Define expected
     base_name = (
-        "SOM_CNV_CALLING/output/bwa.copywriter.P00{i}-T{t}-DNA1-WGS{g}/out/"
-        "bwa.copywriter.P00{i}-T{t}-DNA1-WGS{g}_gene_call.txt"
+        "SOM_CNV_CALLING/output/bwa.copywriter.P00{i}-T{t}-DNA1-WGS1/out/"
+        "bwa.copywriter.P00{i}-T{t}-DNA1-WGS1_gene_call.txt"
     )
-    expected = [base_name.format(i=i, t=t, g=g) for i, t, g in ((1, 1, 1), (2, 1, 2), (2, 2, 1))]
+    expected = [base_name.format(i=i, t=t) for i, t in ((1, 1), (2, 1), (2, 2))]
     # Get actual
     actual = cbioportal_export_workflow.get_input_files("cbioportal_cna_data", "gistic")
     assert actual == expected
@@ -414,10 +414,10 @@ def test_cbioportal_cna_data_step_part_get_input_files_segments(cbioportal_expor
     """Tests cbioportalCnaFilesStepPart.get_input_files() - action 'segments'"""
     # Define expected
     base_name = (
-        "SOM_CNV_CALLING/output/bwa.copywriter.P00{i}-T{t}-DNA1-WGS{g}/out/"
-        "bwa.copywriter.P00{i}-T{t}-DNA1-WGS{g}_segments.txt"
+        "SOM_CNV_CALLING/output/bwa.copywriter.P00{i}-T{t}-DNA1-WGS1/out/"
+        "bwa.copywriter.P00{i}-T{t}-DNA1-WGS1_segments.txt"
     )
-    expected = [base_name.format(i=i, t=t, g=g) for i, t, g in ((1, 1, 1), (2, 1, 2), (2, 2, 1))]
+    expected = [base_name.format(i=i, t=t) for i, t in ((1, 1), (2, 1), (2, 2))]
     # Get actual
     actual = cbioportal_export_workflow.get_input_files("cbioportal_cna_data", "segments")
     assert actual == expected

--- a/tests/snappy_pipeline/workflows/test_workflows_gene_expression_quantification_processed_fastq.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_gene_expression_quantification_processed_fastq.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+"""Tests for the hla_typing workflow module code"""
+
+import textwrap
+
+import pytest
+import ruamel.yaml as ruamel_yaml
+from snakemake.io import Wildcards
+
+from snappy_pipeline.workflows.gene_expression_quantification import (
+    GeneExpressionQuantificationWorkflow,
+)
+
+from .conftest import patch_module_fs
+
+__author__ = "Clemens Messerschmidt"
+
+
+@pytest.fixture(scope="module")  # otherwise: performance issues
+def minimal_config():
+    """Return YAML parsing result for (germline) configuration"""
+    yaml = ruamel_yaml.YAML()
+    return yaml.load(
+        textwrap.dedent(
+            r"""
+        static_data_config:
+          reference:
+            path: /path/to/ref.fa
+
+        step_config:
+          gene_expression_quantification:
+            path_link_in: "/preprocess"
+          ngs_mapping:
+            tools:
+              rna: ['star']
+            star:
+              path_index: /path/to/star/index
+
+        data_sets:
+          first_batch:
+            file: sheet.tsv
+            search_patterns:
+            - {'left': '*/*/*_R1.fastq.gz', 'right': '*/*/*_R2.fastq.gz'}
+            search_paths: ['/path']
+            type: matched_cancer
+            naming_scheme: only_secondary_id
+        """
+        ).lstrip()
+    )
+
+
+@pytest.fixture
+def gene_expression_quantification_workflow(
+    dummy_workflow,
+    minimal_config,
+    config_lookup_paths,
+    work_dir,
+    config_paths,
+    cancer_sheet_fake_fs_path_link_in,
+    mocker,
+):
+    """Return GeneExpressionQuantificationWorkflow object pre-configured with cancer sheet"""
+    # Patch out file-system related things in abstract (the crawling link in step is defined there)
+    patch_module_fs("snappy_pipeline.workflows.abstract", cancer_sheet_fake_fs_path_link_in, mocker)
+    dummy_workflow.globals = {"ngs_mapping": lambda x: "NGS_MAPPING/" + x}
+    # Construct the workflow object
+    return GeneExpressionQuantificationWorkflow(
+        dummy_workflow,
+        minimal_config,
+        config_lookup_paths,
+        config_paths,
+        work_dir,
+    )
+
+
+# Tests for FeatureCountsStepPart ------------------------------------------------------------------
+
+
+def test_featurecounts_step_part_get_input_files(gene_expression_quantification_workflow):
+    """Tests FeatureCountsStepPart.get_input_files()"""
+    # Define expected
+    ngs_mapping_base_out = "NGS_MAPPING/output/star.P001-T1-RNA1-mRNA_seq1/out/"
+    expected = {
+        "bai": ngs_mapping_base_out + "star.P001-T1-RNA1-mRNA_seq1.bam.bai",
+        "bam": ngs_mapping_base_out + "star.P001-T1-RNA1-mRNA_seq1.bam",
+    }
+    # Get actual
+    wildcards = Wildcards(fromdict={"library_name": "P001-T1-RNA1-mRNA_seq1", "mapper": "star"})
+    actual = gene_expression_quantification_workflow.get_input_files("featurecounts", "run")(
+        wildcards
+    )
+    assert actual == expected
+
+
+def test_featurecounts_step_part_get_output_files(gene_expression_quantification_workflow):
+    """Tests FeatureCountsStepPart.get_output_files()"""
+    # Define expected
+    base_out = "work/{mapper}.featurecounts.{library_name}/out/"
+    expected = {
+        "tsv": base_out + "{mapper}.featurecounts.{library_name}.tsv",
+        "tsv_md5": base_out + "{mapper}.featurecounts.{library_name}.tsv.md5",
+        "summary": base_out + "{mapper}.featurecounts.{library_name}.tsv.summary",
+        "summary_md5": base_out + "{mapper}.featurecounts.{library_name}.tsv.summary.md5",
+    }
+
+    # Get actual
+    actual = gene_expression_quantification_workflow.get_output_files("featurecounts", "run")
+    assert actual == expected
+
+
+def test_featurecounts_step_part_get_log_file(gene_expression_quantification_workflow):
+    """Tests FeatureCountsStepPart.get_log_file()"""
+    expected = (
+        "work/{mapper}.featurecounts.{library_name}/log/{mapper}.featurecounts.{library_name}.log"
+    )
+    actual = gene_expression_quantification_workflow.get_log_file("featurecounts", "run").get("log")
+    assert actual == expected
+
+
+def test_featurecounts_step_part_get_resource(gene_expression_quantification_workflow):
+    """Tests FeatureCountsStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 2, "time": "1-00:00:00", "memory": "6700M", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = gene_expression_quantification_workflow.get_resource(
+            "featurecounts", "run", resource
+        )
+        assert actual == expected, msg_error
+
+
+# Tests for SalmonStepPart    ----------------------------------------------------------------------
+
+
+def test_salmon_step_part_get_resource(gene_expression_quantification_workflow):
+    """Tests SalmonStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 16, "time": "04:00:00", "memory": "2500M", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = gene_expression_quantification_workflow.get_resource("salmon", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for QCStepPartDuplication ------------------------------------------------------------------
+
+
+def test_duplication_step_part_get_resource(gene_expression_quantification_workflow):
+    """Tests QCStepPartDuplication.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 1, "time": "3-00:00:00", "memory": "127G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = gene_expression_quantification_workflow.get_resource(
+            "duplication", "run", resource
+        )
+        assert actual == expected, msg_error
+
+
+# Tests for QCStepPartDupradar ---------------------------------------------------------------------
+
+
+def test_dupradar_step_part_get_resource(gene_expression_quantification_workflow):
+    """Tests QCStepPartDupradar.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 8, "time": "4-00:00:00", "memory": "6700M", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = gene_expression_quantification_workflow.get_resource("dupradar", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for QCStepPartRnaseqc ----------------------------------------------------------------------
+
+
+def test_rnaseqc_step_part_get_resource(gene_expression_quantification_workflow):
+    """Tests QCStepPartRnaseqc.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 1, "time": "03:59:00", "memory": "16G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = gene_expression_quantification_workflow.get_resource("rnaseqc", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for QCStepPartStats ------------------------------------------------------------------------
+
+
+def test_stats_step_part_get_resource(gene_expression_quantification_workflow):
+    """Tests QCStepPartStats.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 1, "time": "03:59:00", "memory": "4G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = gene_expression_quantification_workflow.get_resource("stats", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for GeneExpressionQuantificationWorkflow ---------------------------------------------------
+
+
+def test_gene_expression_quantification_workflow_substeps(gene_expression_quantification_workflow):
+    """Tests simple functionality of the workflow: checks if sub steps are created,
+    i.e., the tools associated with gene expression quantification."""
+    # Check created sub steps
+    expected = [
+        "duplication",
+        "dupradar",
+        "featurecounts",
+        "link_in",
+        "link_out",
+        "rnaseqc",
+        "salmon",
+        "stats",
+        "strandedness",
+    ]
+    actual = list(sorted(gene_expression_quantification_workflow.sub_steps.keys()))
+    assert actual == expected
+
+
+def test_gene_expression_quantification_workflow_files(gene_expression_quantification_workflow):
+    """Tests simple functionality of the workflow: checks if file structure is created according
+    to the expected results from the tools, namely: duplication, dupradar, featurecounts,
+    link_in, link_out, rnaseqc, salmon, stats, strandedness."""
+    # Check result file construction
+    base_name_out = (
+        "output/{step}.P00{i}-T{i}-RNA1-mRNA_seq1/out/{step}.P00{i}-T{i}-RNA1-mRNA_seq1{ext}"
+    )
+    # Add expected Salmon out files
+    expected = [
+        base_name_out.format(step="salmon", i=i, ext=ext)
+        for i in (1, 2)  # only for indices
+        for ext in (
+            ".gene.sf",
+            ".gene.sf.md5",
+            ".transcript.sf",
+            ".transcript.sf.md5",
+        )
+    ]
+    # Add expected star duplication out files
+    expected += [
+        base_name_out.format(step="star.duplication", i=i, ext=ext)
+        for i in (1, 2)  # only for indices
+        for ext in (
+            ".pos.DupRate.xls",
+            ".pos.DupRate.xls.md5",
+            ".seq.DupRate.xls",
+            ".seq.DupRate.xls.md5",
+        )
+    ]
+    # Add expected star dupradar out files
+    expected += [
+        base_name_out.format(step="star.dupradar", i=i, ext=ext)
+        for i in (1, 2)  # only for indices
+        for ext in (
+            ".dupradar.tsv",
+            ".dupradar.tsv.md5",
+        )
+    ]
+    # Add expected star featurecounts out files
+    expected += [
+        base_name_out.format(step="star.featurecounts", i=i, ext=ext)
+        for i in (1, 2)  # only for indices
+        for ext in (
+            ".tsv",
+            ".tsv.md5",
+            ".tsv.summary",
+            ".tsv.summary.md5",
+        )
+    ]
+    # Add expected star rnaseqc out files
+    expected += [
+        base_name_out.format(step="star.rnaseqc", i=i, ext=ext)
+        for i in (1, 2)  # only for indices
+        for ext in (
+            ".{s}{e}".format(s=s, e=e)
+            for s in (
+                "gapLengthHist_high",
+                "gapLengthHist_low",
+                "gapLengthHist_medium",
+                "meanCoverage_high",
+                "meanCoverage_low",
+                "meanCoverage_medium",
+                "meanCoverageNorm_high",
+                "meanCoverageNorm_low",
+                "meanCoverageNorm_medium",
+            )
+            for e in (".txt", ".txt.md5")
+        )
+    ]
+    # Add expected star rnaseqc out files - cont.
+    expected += [
+        base_name_out.format(step="star.rnaseqc", i=i, ext=ext)
+        for i in (1, 2)  # only for indices
+        for ext in (
+            ".metrics.tsv",
+            ".metrics.tsv.md5",
+        )
+    ]
+    # Add expected star stats out files
+    expected += [
+        base_name_out.format(step="star.stats", i=i, ext=ext)
+        for i in (1, 2)  # only for indices
+        for ext in (
+            ".read_alignment_report.tsv",
+            ".read_alignment_report.tsv.md5",
+        )
+    ]
+    # Add expected star strandedness out files
+    expected += [
+        base_name_out.format(step="star.strandedness", i=i, ext=ext)
+        for i in (1, 2)  # only for indices
+        for ext in (
+            ".decision",
+            ".decision.md5",
+            ".tsv",
+            ".tsv.md5",
+        )
+    ]
+    expected = set(expected)
+
+    # Get actual
+    actual = set(gene_expression_quantification_workflow.get_result_files())
+
+    assert actual == expected

--- a/tests/snappy_pipeline/workflows/test_workflows_hla_typing_processed_fastq.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_hla_typing_processed_fastq.py
@@ -25,6 +25,10 @@ def minimal_config():
           reference:
             path: /path/to/ref.fa
 
+        step_config:
+          hla_typing:
+            path_link_in: /preprocess
+            tools: [optitype]
         data_sets:
           first_batch:
             file: sheet.tsv
@@ -45,12 +49,12 @@ def hla_typing_workflow(
     config_lookup_paths,
     work_dir,
     config_paths,
-    cancer_sheet_fake_fs,
+    cancer_sheet_fake_fs_path_link_in,
     mocker,
 ):
     """Return HlaTypingWorkflow object pre-configured with cancer sheet"""
     # Patch out file-system related things in abstract (the crawling link in step is defined there)
-    patch_module_fs("snappy_pipeline.workflows.abstract", cancer_sheet_fake_fs, mocker)
+    patch_module_fs("snappy_pipeline.workflows.abstract", cancer_sheet_fake_fs_path_link_in, mocker)
     # Construct the workflow object
     return HlaTypingWorkflow(
         dummy_workflow,
@@ -99,10 +103,10 @@ def test_optitype_step_part_get_args_input(hla_typing_workflow):
     wildcards = Wildcards(fromdict={"library_name": "P001-T1-DNA1-WGS1"})
     sinput = hla_typing_workflow.substep_dispatch("optitype", "get_args", "run")(wildcards)
     assert sinput["input"]["reads_left"] == [
-        "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001_T1_DNA1_WGS1_R1.fastq.gz"
+        "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz"
     ]
     assert sinput["input"]["reads_right"] == [
-        "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/P001_T1_DNA1_WGS1_R2.fastq.gz"
+        "work/input_links/P001-T1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz"
     ]
 
 

--- a/tests/snappy_pipeline/workflows/test_workflows_ngs_data_qc_processed_fastq.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_ngs_data_qc_processed_fastq.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ngs_data_qc workflow module code"""
+
+import textwrap
+
+import pytest
+import ruamel.yaml as ruamel_yaml
+from snakemake.io import Wildcards
+
+from snappy_pipeline.workflows.ngs_data_qc import NgsDataQcWorkflow
+
+from .conftest import patch_module_fs
+
+
+@pytest.fixture(scope="module")  # otherwise: performance issues
+def minimal_config():
+    """Return YAML parsing result for (germline) configuration"""
+    yaml = ruamel_yaml.YAML()
+    return yaml.load(
+        textwrap.dedent(
+            r"""
+        static_data_config:
+          reference:
+            path: /path/to/ref.fa
+
+        step_config:
+          ngs_data_qc:
+            path_link_in: "/preprocess"
+            tools: ['fastqc']
+
+        data_sets:
+          first_batch:
+            file: sheet.tsv
+            search_patterns:
+            - {'left': '*/*/*_R1.fastq.gz', 'right': '*/*/*_R2.fastq.gz'}
+            search_paths: ['/path']
+            type: germline_variants
+            naming_scheme: only_secondary_id
+            pedigree_field: pedigree_field
+        """
+        ).lstrip()
+    )
+
+
+@pytest.fixture
+def ngs_data_qc(
+    dummy_workflow,
+    minimal_config,
+    config_lookup_paths,
+    work_dir,
+    config_paths,
+    germline_sheet_fake_fs_path_link_in,
+    aligner_indices_fake_fs,
+    mocker,
+):
+    """Return NgsDataQcWorkflow object pre-configured with germline sheet"""
+    # Patch out file-system related things in abstract (the crawling link in step is defined there)
+    patch_module_fs(
+        "snappy_pipeline.workflows.abstract", germline_sheet_fake_fs_path_link_in, mocker
+    )
+    # Patch out files for aligner indices
+    patch_module_fs("snappy_pipeline.workflows.ngs_data_qc", aligner_indices_fake_fs, mocker)
+    # Construct the workflow object
+    return NgsDataQcWorkflow(
+        dummy_workflow,
+        minimal_config,
+        config_lookup_paths,
+        config_paths,
+        work_dir,
+    )
+
+
+# Tests for FastQcReportStepPart -------------------------------------------------------------------
+
+
+def test_fastqc_step_part_get_args(ngs_data_qc):
+    """Tests FastQcReportStepPart.get_args()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = {
+        "num_threads": 1,
+        "more_reads": [
+            "work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz",
+            "work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz",
+        ],
+    }
+    # Get actual and assert
+    actual = ngs_data_qc.get_args("fastqc", "run")(wildcards)
+    assert actual == expected
+
+
+def test_fastqc_step_part_get_input_files(ngs_data_qc):
+    """Tests FastQcReportStepPart.get_input_files()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = "work/input_links/P001-N1-DNA1-WGS1/.done"
+    # Get actual and assert
+    actual = ngs_data_qc.get_input_files("fastqc", "run")(wildcards)
+    assert actual == expected
+
+
+def test_fastqc_step_part_get_output_files(ngs_data_qc):
+    """Tests FastQcReportStepPart.get_output_files()"""
+    # Define expected
+    expected = {"fastqc_done": "work/{library_name}/report/fastqc/.done"}
+    # Get actual
+    actual = ngs_data_qc.get_output_files("fastqc", "run")
+    assert actual == expected
+
+
+def test_fastqc_step_part_get_log_file(ngs_data_qc):
+    """Tests FastQcReportStepPart.get_log_file()"""
+    # Define expected
+    expected = "work/{library_name}/log/snakemake.fastqc.log"
+    # Get actual
+    actual = ngs_data_qc.get_log_file("fastqc", "run")
+    assert actual == expected
+
+
+def test_fastqc_step_part_get_resource_usage(ngs_data_qc):
+    """Tests FastQcReportStepPart.get_resource_usage()"""
+    # Define expected: default defined in workflow.abstract
+    expected_dict = {"threads": 1, "time": "01:00:00", "memory": "2G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_data_qc.get_resource("fastqc", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for NgsDataQcWorkflow ----------------------------------------------------------------------
+
+
+def test_ngs_data_qc_workflow_steps(ngs_data_qc):
+    """Tests simple functionality of the workflow: checks if sub steps are created."""
+    # Check created sub steps
+    expected = ["fastqc", "link_in", "link_out"]
+    actual = list(sorted(ngs_data_qc.sub_steps.keys()))
+    assert actual == expected
+
+
+def test_ngs_data_qc_workflow_files(ngs_data_qc):
+    """Tests simple functionality of the workflow: checks if file structure is created according
+    to the expected results from the tools."""
+    # Check result file construction
+    expected = [f"output/P00{i}-N1-DNA1-WGS1/report/fastqc/.done" for i in range(1, 7)]
+    actual = sorted(ngs_data_qc.get_result_files())
+    assert actual == expected

--- a/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping_processed_fastq.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping_processed_fastq.py
@@ -1,0 +1,892 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ngs_mapping workflow module code using preprocessed FASTQ"""
+
+from collections import OrderedDict
+from copy import deepcopy
+import io
+import textwrap
+
+from biomedsheets.io_tsv import read_generic_tsv_sheet, read_germline_tsv_sheet
+import pytest
+import ruamel.yaml as ruamel_yaml
+from snakemake.io import Wildcards
+
+from snappy_pipeline.workflows.ngs_mapping import NgsMappingWorkflow
+
+from .common import get_expected_log_files_dict
+from .conftest import patch_module_fs
+
+
+@pytest.fixture(scope="module")  # otherwise: performance issues
+def minimal_config():
+    """Return YAML parsing result for (germline) configuration"""
+    yaml = ruamel_yaml.YAML()
+    return yaml.load(
+        textwrap.dedent(
+            r"""
+        static_data_config:
+          reference:
+            path: /path/to/ref.fa
+
+        step_config:
+          bam_collect_doc:
+            enabled: true
+          ngs_mapping:
+            path_link_in: "/preprocess"
+            tools:
+              dna: ['bwa']
+            target_coverage_report:
+              path_target_interval_list_mapping:
+              - pattern: "Agilent SureSelect Human All Exon V6.*"
+                name: Agilent_SureSelect_Human_All_Exon_V6
+                path: path/to/SureSelect_Human_All_Exon_V6_r2.bed
+            compute_coverage_bed: true
+            bwa:
+              path_index: /path/to/bwa/index.fasta
+
+        data_sets:
+          first_batch:
+            file: sheet.tsv
+            search_patterns:
+            - {"left": "*/*/*_R1.fastq.gz", "right": "*/*/*_R2.fastq.gz"}
+            search_paths: ['/path']
+            type: germline_variants
+            naming_scheme: only_secondary_id
+            pedigree_field: pedigree_field
+        """
+        ).lstrip()
+    )
+
+
+@pytest.fixture
+def ngs_mapping_workflow(
+    dummy_workflow,
+    minimal_config,
+    config_lookup_paths,
+    work_dir,
+    config_paths,
+    germline_sheet_fake_fs_path_link_in,
+    aligner_indices_fake_fs,
+    mocker,
+):
+    """Return NgsMappingWorkflow object pre-configured with germline sheet"""
+    # Patch out file-system related things in abstract (the crawling link in step is defined there)
+    patch_module_fs(
+        "snappy_pipeline.workflows.abstract", germline_sheet_fake_fs_path_link_in, mocker
+    )
+    # Patch out files for aligner indices
+    patch_module_fs("snappy_pipeline.workflows.ngs_mapping", aligner_indices_fake_fs, mocker)
+    # Construct the workflow object
+    return NgsMappingWorkflow(
+        dummy_workflow,
+        minimal_config,
+        config_lookup_paths,
+        config_paths,
+        work_dir,
+    )
+
+
+def get_expected_output_files_dict(bam_base_out, report_base_out):
+    """Helper method.
+
+    :param bam_base_out: Expected name pattern of BAM associated files without extension.
+    For example if the full path would be '/path/to/step_part.bam', argument should be
+    '/path/to/step_part'.
+    :type bam_base_out: str
+
+    :param report_base_out: Expected name pattern of report associated files without extension.
+    For example if the full path would be '/path/to/step_report.bam.bamstats.html', argument should
+    be '/path/to/step_report'.
+
+    :return: Returns dictionary with expected path for BAM and report associated files based on the
+    provided input.
+    """
+    # Define expected
+    expected = {
+        "bam": bam_base_out + ".bam",
+        "bam_bai": bam_base_out + ".bam.bai",
+        "bam_bai_md5": bam_base_out + ".bam.bai.md5",
+        "bam_md5": bam_base_out + ".bam.md5",
+        "report_bamstats_html": report_base_out + ".bam.bamstats.html",
+        "report_bamstats_html_md5": report_base_out + ".bam.bamstats.html.md5",
+        "report_bamstats_txt": report_base_out + ".bam.bamstats.txt",
+        "report_bamstats_txt_md5": report_base_out + ".bam.bamstats.txt.md5",
+        "report_flagstats_txt": report_base_out + ".bam.flagstats.txt",
+        "report_flagstats_txt_md5": report_base_out + ".bam.flagstats.txt.md5",
+        "report_idxstats_txt": report_base_out + ".bam.idxstats.txt",
+        "report_idxstats_txt_md5": report_base_out + ".bam.idxstats.txt.md5",
+    }
+    # Return
+    return expected
+
+
+# Test for project validation ----------------------------------------------------------------------
+
+
+def test_extraction_type_check(
+    ngs_mapping_workflow,
+    germline_sheet_tsv,
+    generic_rna_sheet_tsv,
+    generic_mix_extraction_sheet_tsv,
+):
+    """Tests extraction type check method."""
+    # Create dna sample sheet based on germline sheet
+    germline_sheet_io = io.StringIO(germline_sheet_tsv)
+    dna_sheet = read_germline_tsv_sheet(germline_sheet_io)
+
+    # Create rna sample sheet
+    rna_sheet_io = io.StringIO(generic_rna_sheet_tsv)
+    rna_sheet = read_generic_tsv_sheet(rna_sheet_io)
+
+    # Create mix data sample sheet
+    mix_sheet_io = io.StringIO(generic_mix_extraction_sheet_tsv)
+    mix_sheet = read_generic_tsv_sheet(mix_sheet_io)
+
+    # Evaluate if only DNA is True
+    dna_bool, rna_bool = ngs_mapping_workflow.extraction_type_check(sample_sheet=dna_sheet)
+    assert dna_bool, "Germline extraction type are set to DNA by default."
+    assert not rna_bool, "No RNA sample was included in the sample sheet."
+
+    # Evaluate if only RNA is True
+    dna_bool, rna_bool = ngs_mapping_workflow.extraction_type_check(sample_sheet=rna_sheet)
+    assert not dna_bool, "No DNA sample was included in the sample sheet."
+    assert rna_bool, "Only RNA samples were included in the sample sheet."
+
+    # Evaluate if both DNA and RNA are True
+    dna_bool, rna_bool = ngs_mapping_workflow.extraction_type_check(sample_sheet=mix_sheet)
+    assert dna_bool, "Sample sheet contains both DNA and RNA."
+    assert rna_bool, "Sample sheet contains both DNA and RNA."
+
+
+def test_project_validation_germline(
+    ngs_mapping_workflow, germline_sheet_tsv, generic_rna_sheet_tsv, minimal_config
+):
+    """Tests project validation method in ngs mapping workflow"""
+    # Convert yaml to dict
+    minimal_config_dict = deepcopy(minimal_config)
+    minimal_config_dict = dict(minimal_config_dict)
+    minimal_config_dict = minimal_config_dict["step_config"].get("ngs_mapping", OrderedDict())
+
+    # Create germline sample sheet
+    germline_sheet_io = io.StringIO(germline_sheet_tsv)
+    germline_sheet = read_germline_tsv_sheet(germline_sheet_io)
+
+    # Create rna sample sheet
+    rna_sheet_io = io.StringIO(generic_rna_sheet_tsv)
+    rna_sheet = read_generic_tsv_sheet(rna_sheet_io)
+
+    # Method returns None without exception, cause DNA sample sheet and DNA tool defined in config
+    out = ngs_mapping_workflow.validate_project(
+        config_dict=minimal_config_dict, sample_sheets_list=[germline_sheet]
+    )
+    assert out is None, "No exception expected: DNA sample sheet and DNA tool defined in config."
+
+    # Exception raised cause no RNA mapper defined in config
+    with pytest.raises(Exception) as exec_info:
+        ngs_mapping_workflow.validate_project(
+            config_dict=minimal_config_dict, sample_sheets_list=[rna_sheet]
+        )
+    error_msg = "RNA sample provided, but config only contains DNA mapper."
+    assert exec_info.value.args[0] is not None, error_msg
+
+    # Exception raised cause only DNA mapper defined in config
+    with pytest.raises(Exception) as exec_info:
+        ngs_mapping_workflow.validate_project(
+            config_dict=minimal_config_dict, sample_sheets_list=[germline_sheet, rna_sheet]
+        )
+    error_msg = "DNA and RNA sample provided, but config only contains DNA mapper."
+    assert exec_info.value.args[0] is not None, error_msg
+
+    # Update config and remove RNA exception
+    minimal_config_dict["tools"]["rna"] = ["rna_mapper"]
+    out = ngs_mapping_workflow.validate_project(
+        config_dict=minimal_config_dict, sample_sheets_list=[germline_sheet, rna_sheet]
+    )
+    error_msg = (
+        "No exception expected: DNA, RNA sample sheet and respective tools defined in config."
+    )
+    assert out is None, error_msg
+
+    # Update config and introduce DNA exception
+    minimal_config_dict["tools"]["dna"] = []
+    with pytest.raises(Exception) as exec_info:
+        ngs_mapping_workflow.validate_project(
+            config_dict=minimal_config_dict, sample_sheets_list=[germline_sheet, rna_sheet]
+        )
+    error_msg = "DNA and RNA sample provided, but config only contains RNA mapper."
+    assert exec_info.value.args[0] is not None, error_msg
+
+    # Exception raised cause no DNA mapper defined in config
+    with pytest.raises(Exception) as exec_info:
+        ngs_mapping_workflow.validate_project(
+            config_dict=minimal_config_dict, sample_sheets_list=[germline_sheet]
+        )
+    error_msg = "DNA and RNA sample provided, but config only contains RNA mapper."
+    assert exec_info.value.args[0] is not None, error_msg
+
+
+# Tests for BwaStepPart ----------------------------------------------------------------------------
+
+
+def test_bwa_step_part_get_args(ngs_mapping_workflow):
+    """Tests BaseStepPart.get_args()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    base_name = "work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/"
+    expected = {
+        "input": {
+            "reads_left": [base_name + "P001_R1.fastq.gz"],
+            "reads_right": [base_name + "P001_R2.fastq.gz"],
+        },
+        "platform": "ILLUMINA",
+        "sample_name": "P001-N1-DNA1-WGS1",
+    }
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_args("bwa", "run")(wildcards)
+    assert actual == expected
+
+
+def test_bwa_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests BaseStepPart.get_input_files()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = "work/input_links/P001-N1-DNA1-WGS1/.done"
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_input_files("bwa", "run")(wildcards)
+    assert actual == expected
+
+
+def test_bwa_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests BaseStepPart.get_output_files()"""
+    # Define expected
+    bam_base_out = "work/bwa.{library_name}/out/bwa.{library_name}"
+    report_base_out = "work/bwa.{library_name}/report/bam_qc/bwa.{library_name}"
+    expected = get_expected_output_files_dict(bam_base_out, report_base_out)
+    # Get actual
+    actual = ngs_mapping_workflow.get_output_files("bwa", "run")
+    assert actual == expected
+
+
+def test_bwa_step_part_get_log_file(ngs_mapping_workflow):
+    """Tests BaseStepPart.get_log_file()"""
+    # Define expected
+    expected = get_expected_log_files_dict(
+        base_out="work/bwa.{library_name}/log/bwa.{library_name}"
+    )
+    # Get actual
+    actual = ngs_mapping_workflow.get_log_file("bwa", "run")
+    assert actual == expected
+
+
+def test_bwa_step_part_get_resource(ngs_mapping_workflow):
+    """Tests BaseStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 16, "time": "3-00:00:00", "memory": "73728M", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_mapping_workflow.get_resource("bwa", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for StarStepPart --------------------------------------------------------------------------
+
+
+def test_star_step_part_get_args(ngs_mapping_workflow):
+    """Tests StarStepPart.get_args()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = {
+        "input": {
+            "reads_left": ["work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz"],
+            "reads_right": [
+                "work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz"
+            ],
+        },
+        "platform": "ILLUMINA",
+        "sample_name": "P001-N1-DNA1-WGS1",
+    }
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_args("star", "run")(wildcards)
+    assert actual == expected
+
+
+def test_star_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests StarStepPart.get_input_files()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = "work/input_links/P001-N1-DNA1-WGS1/.done"
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_input_files("star", "run")(wildcards)
+    assert actual == expected
+
+
+def test_star_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests StarStepPart.get_output_files()"""
+    # Define expected
+    bam_base_out = "work/star.{library_name}/out/star.{library_name}"
+    report_base_out = "work/star.{library_name}/report/bam_qc/star.{library_name}"
+    expected = get_expected_output_files_dict(bam_base_out, report_base_out)
+    # Get actual
+    actual = ngs_mapping_workflow.get_output_files("star", "run")
+    assert actual == expected
+
+
+def test_star_step_part_get_log_file(ngs_mapping_workflow):
+    """Tests StarStepPart.get_log_file()"""
+    # Define expected
+    expected = get_expected_log_files_dict(
+        base_out="work/star.{library_name}/log/star.{library_name}"
+    )
+    # Get actual
+    actual = ngs_mapping_workflow.get_log_file("star", "run")
+    assert actual == expected
+
+
+def test_star_step_part_get_resource(ngs_mapping_workflow):
+    """Tests StarStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 16, "time": "2-00:00:00", "memory": "56G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_mapping_workflow.get_resource("star", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for Minimap2StepPart -----------------------------------------------------------------------
+
+
+def test_minimap2_step_part_get_args(ngs_mapping_workflow):
+    """Tests Minimap2StepPart.get_args()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = {
+        "input": {
+            "reads_left": ["work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz"],
+            "reads_right": [
+                "work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz"
+            ],
+        },
+        "platform": "ILLUMINA",
+        "sample_name": "P001-N1-DNA1-WGS1",
+    }
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_args("minimap2", "run")(wildcards)
+    assert actual == expected
+
+
+def test_minimap2_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests Minimap2StepPart.get_input_files()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = "work/input_links/P001-N1-DNA1-WGS1/.done"
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_input_files("minimap2", "run")(wildcards)
+    assert actual == expected
+
+
+def test_minimap2_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests Minimap2StepPart.get_output_files()"""
+    # Define expected
+    bam_base_out = "work/minimap2.{library_name}/out/minimap2.{library_name}"
+    report_base_out = "work/minimap2.{library_name}/report/bam_qc/minimap2.{library_name}"
+    expected = get_expected_output_files_dict(bam_base_out, report_base_out)
+    # Get actual
+    actual = ngs_mapping_workflow.get_output_files("minimap2", "run")
+    assert actual == expected
+
+
+def test_minimap2_step_part_get_log_file(ngs_mapping_workflow):
+    """Tests Minimap2StepPart.get_log_file()"""
+    # Define expected
+    expected = get_expected_log_files_dict(
+        base_out="work/minimap2.{library_name}/log/minimap2.{library_name}"
+    )
+    # Get actual
+    actual = ngs_mapping_workflow.get_log_file("minimap2", "run")
+    assert actual == expected
+
+
+def test_minimap2_step_part_get_resource(ngs_mapping_workflow):
+    """Tests Minimap2StepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 16, "time": "4-00:00:00", "memory": "56G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_mapping_workflow.get_resource("minimap2", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for NgmlrStepPart -----------------------------------------------------------------------
+
+
+def test_ngmlr_step_part_get_args(ngs_mapping_workflow):
+    """Tests NgmlrStepPart.get_args()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = {
+        "input": {
+            "reads_left": ["work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R1.fastq.gz"],
+            "reads_right": [
+                "work/input_links/P001-N1-DNA1-WGS1/FCXXXXXX/L001/out/P001_R2.fastq.gz"
+            ],
+        },
+        "platform": "ILLUMINA",
+        "sample_name": "P001-N1-DNA1-WGS1",
+    }
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_args("ngmlr", "run")(wildcards)
+    assert actual == expected
+
+
+def test_ngmlr_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests NgmlrStepPart.get_input_files()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = "work/input_links/P001-N1-DNA1-WGS1/.done"
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_input_files("ngmlr", "run")(wildcards)
+    assert actual == expected
+
+
+def test_ngmlr_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests NgmlrStepPart.get_output_files()"""
+    # Define expected
+    bam_base_out = "work/ngmlr.{library_name}/out/ngmlr.{library_name}"
+    report_base_out = "work/ngmlr.{library_name}/report/bam_qc/ngmlr.{library_name}"
+    expected = get_expected_output_files_dict(bam_base_out, report_base_out)
+    # Get actual
+    actual = ngs_mapping_workflow.get_output_files("ngmlr", "run")
+    assert actual == expected
+
+
+def test_ngmlr_step_part_get_log_file(ngs_mapping_workflow):
+    """Tests NgmlrStepPart.get_log_file()"""
+    # Define expected
+    expected = get_expected_log_files_dict(
+        base_out="work/ngmlr.{library_name}/log/ngmlr.{library_name}"
+    )
+    # Get actual
+    actual = ngs_mapping_workflow.get_log_file("ngmlr", "run")
+    assert actual == expected
+
+
+def test_ngmlr_step_part_get_resource(ngs_mapping_workflow):
+    """Tests NgmlrStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 16, "time": "4-00:00:00", "memory": "50G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_mapping_workflow.get_resource("ngmlr", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for ExternalStepPart -----------------------------------------------------------------------
+
+
+# TODO(holtgrewe): the fake file system should be setup with fake BAM files.
+def test_external_step_part_get_args(ngs_mapping_workflow):
+    """Tests ExternalStepPart.get_args()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = {"input": [], "platform": "EXTERNAL", "sample_name": "P001-N1-DNA1-WGS1"}
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_args("external", "run")(wildcards)
+    assert actual == expected
+
+
+def test_external_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests ExternalStepPart.get_input_files()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"library_name": "P001-N1-DNA1-WGS1"})
+    expected = "work/input_links/P001-N1-DNA1-WGS1/.done"
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_input_files("external", "run")(wildcards)
+    assert actual == expected
+
+
+def test_external_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests ExternalStepPart.get_output_files()"""
+    # Define expected
+    bam_base_out = "work/external.{library_name}/out/external.{library_name}"
+    report_base_out = "work/external.{library_name}/report/bam_qc/external.{library_name}"
+    expected = get_expected_output_files_dict(bam_base_out, report_base_out)
+    # Get actual
+    actual = ngs_mapping_workflow.get_output_files("external", "run")
+    assert actual == expected
+
+
+def test_external_step_part_get_resource(ngs_mapping_workflow):
+    """Tests ExternalStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 1, "time": "00:10:00", "memory": "1G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_mapping_workflow.get_resource("external", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for GatkPostBamStepPart -------------------------------------------------------------------
+
+
+def test_gatk_post_bam_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests GatkPostBamStepPart.get_input_files()"""
+    expected = "work/{mapper}.{library_name}/out/{mapper}.{library_name}.bam"
+    actual = ngs_mapping_workflow.get_input_files("gatk_post_bam", "run")
+    assert actual == expected
+
+
+def test_gatk_post_bam_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests GatkPostBamStepPart.get_output_files()"""
+    # Define expected
+    base_name_out = "work/{mapper}.{library_name}/out/{mapper}.{library_name}"
+    expected = {
+        "bai_md5_realigned": base_name_out + ".realigned.bam.bai.md5",
+        "bai_md5_recalibrated": base_name_out + ".realigned.recalibrated.bam.bai.md5",
+        "bai_realigned": base_name_out + ".realigned.bam.bai",
+        "bai_recalibrated": base_name_out + ".realigned.recalibrated.bam.bai",
+        "bam_md5_realigned": base_name_out + ".realigned.bam.md5",
+        "bam_md5_recalibrated": base_name_out + ".realigned.recalibrated.bam.md5",
+        "bam_realigned": base_name_out + ".realigned.bam",
+        "bam_recalibrated": base_name_out + ".realigned.recalibrated.bam",
+    }
+    # Get actual
+    actual = ngs_mapping_workflow.get_output_files("gatk_post_bam", "run")
+    assert actual == expected
+
+
+def test_gatk_post_bam_step_part_get_log_file(ngs_mapping_workflow):
+    """Tests GatkPostBamStepPart.get_log_file()"""
+    expected = get_expected_log_files_dict(
+        base_out="work/{mapper}.{library_name}/log/gatk_post_bam.{library_name}"
+    )
+    actual = ngs_mapping_workflow.get_log_file("gatk_post_bam", "run")
+    assert actual == expected
+
+
+def test_gatk_post_bam_step_part_get_resource(ngs_mapping_workflow):
+    """Tests GatkPostBamStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 2, "time": "2-00:00:00", "memory": "52G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_mapping_workflow.get_resource("gatk_post_bam", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for LinkOutBamStepPart --------------------------------------------------------------------
+
+
+def test_link_out_bam_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests LinkOutBamStepPart.get_input_files()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"mapper": "bwa", "library_name": "library"})
+    expected = [
+        "work/bwa.library/out/bwa.library.bam",
+        "work/bwa.library/out/bwa.library.bam.bai",
+        "work/bwa.library/out/bwa.library.bam.md5",
+        "work/bwa.library/out/bwa.library.bam.bai.md5",
+    ]
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_input_files("link_out_bam", "run")(wildcards)
+    assert actual == expected
+
+
+def test_link_out_bam_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests LinkOutBamStepPart.get_output_files()"""
+    # Define expected
+    expected = [
+        "output/{mapper}.{library_name}/out/{mapper}.{library_name}.bam",
+        "output/{mapper}.{library_name}/out/{mapper}.{library_name}.bam.bai",
+        "output/{mapper}.{library_name}/out/{mapper}.{library_name}.bam.md5",
+        "output/{mapper}.{library_name}/out/{mapper}.{library_name}.bam.bai.md5",
+    ]
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_output_files("link_out_bam", "run")
+    assert actual == expected
+
+
+def test_link_out_bam_step_part_get_shell_cmd(ngs_mapping_workflow):
+    """Tests LinkOutBamStepPart.get_shell_cmd()"""
+    # Define expected
+    wildcards = Wildcards(fromdict={"mapper": "bwa", "library_name": "library"})
+    b_name = "bwa.library/out/bwa.library.bam"
+    expected = textwrap.dedent(
+        rf"""
+       test -L output/{b_name} || ln -sr work/{b_name} output/{b_name}
+       test -L output/{b_name}.bai || ln -sr work/{b_name}.bai output/{b_name}.bai
+       test -L output/{b_name}.md5 || ln -sr work/{b_name}.md5 output/{b_name}.md5
+       test -L output/{b_name}.bai.md5 || ln -sr work/{b_name}.bai.md5 output/{b_name}.bai.md5
+       """
+    ).strip()
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_shell_cmd("link_out_bam", "run", wildcards)
+    assert actual == expected
+
+
+# Tests for PicardHsMetricsStepPart ----------------------------------------------------------------
+
+
+def test_picard_hs_metrics_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests PicardHsMetricsStepPart.get_input_files()"""
+    # Define expected
+    expected = {
+        "bam": "work/{mapper_lib}/out/{mapper_lib}.bam",
+        "bai": "work/{mapper_lib}/out/{mapper_lib}.bam.bai",
+    }
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_input_files("picard_hs_metrics", "run")
+    assert actual == expected
+
+
+def test_picard_hs_metrics_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests PicardHsMetricsStepPart.get_output_files()"""
+    # Define expected
+    expected = {
+        "txt": "work/{mapper_lib}/report/picard_hs_metrics/{mapper_lib}.txt",
+        "txt_md5": "work/{mapper_lib}/report/picard_hs_metrics/{mapper_lib}.txt.md5",
+    }
+    # Get actual
+    actual = ngs_mapping_workflow.get_output_files("picard_hs_metrics", "run")
+    assert actual == expected
+
+
+def test_picard_hs_metrics_step_part_get_log_file(ngs_mapping_workflow):
+    """Tests PicardHsMetricsStepPart.get_log_file()"""
+    # Define expected
+    expected = "work/{mapper_lib}/log/snakemake.picard_hs_metrics.log"
+    # Get actual
+    actual = ngs_mapping_workflow.get_log_file("picard_hs_metrics", "run")
+    assert actual == expected
+
+
+def test_picard_hs_metrics_step_part_get_resource(ngs_mapping_workflow):
+    """Tests PicardHsMetricsStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 2, "time": "04:00:00", "memory": "20G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_mapping_workflow.get_resource("picard_hs_metrics", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for TargetCoverageReportStepPart ----------------------------------------------------------
+
+
+def test_target_coverage_report_step_part_run_get_input_files(ngs_mapping_workflow):
+    """Tests TargetCoverageReportStepPart.get_input_files() - run"""
+    # Define expected
+    expected = {
+        "bam": "work/bwa.library/out/bwa.library.bam",
+        "bai": "work/bwa.library/out/bwa.library.bam.bai",
+    }
+    # Get actual
+    wildcards = Wildcards(fromdict={"mapper_lib": "bwa.library"})
+    actual = ngs_mapping_workflow.get_input_files("target_coverage_report", "run")(wildcards)
+    assert actual == expected
+
+
+def test_target_coverage_report_step_part_collect_get_input_files(ngs_mapping_workflow):
+    """Tests TargetCoverageReportStepPart.get_input_files() - collect"""
+    # Define expected
+    expected = [
+        "work/bwa.P001-N1-DNA1-WGS1/report/cov_qc/bwa.P001-N1-DNA1-WGS1.txt",
+        "work/bwa.P002-N1-DNA1-WGS1/report/cov_qc/bwa.P002-N1-DNA1-WGS1.txt",
+        "work/bwa.P003-N1-DNA1-WGS1/report/cov_qc/bwa.P003-N1-DNA1-WGS1.txt",
+        "work/bwa.P004-N1-DNA1-WGS1/report/cov_qc/bwa.P004-N1-DNA1-WGS1.txt",
+        "work/bwa.P005-N1-DNA1-WGS1/report/cov_qc/bwa.P005-N1-DNA1-WGS1.txt",
+        "work/bwa.P006-N1-DNA1-WGS1/report/cov_qc/bwa.P006-N1-DNA1-WGS1.txt",
+    ]
+    # Get actual
+    wildcards = Wildcards(fromdict={"mapper_lib": "bwa"})
+    actual = ngs_mapping_workflow.get_input_files("target_coverage_report", "collect")(wildcards)
+    assert actual == expected
+
+
+def test_target_coverage_report_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests TargetCoverageReportStepPart.get_output_files() - run"""
+    expected = {
+        "txt": "work/{mapper_lib}/report/cov_qc/{mapper_lib}.txt",
+        "txt_md5": "work/{mapper_lib}/report/cov_qc/{mapper_lib}.txt.md5",
+    }
+    assert ngs_mapping_workflow.get_output_files("target_coverage_report", "run") == expected
+
+
+def test_target_coverage_report_step_part_run_get_log_file(ngs_mapping_workflow):
+    """Tests TargetCoverageReportStepPart.get_log_file() - run"""
+    expected = "work/{mapper_lib}/log/snakemake.target_coverage.log"
+    assert ngs_mapping_workflow.get_log_file("target_coverage_report", "run") == expected
+
+
+def test_target_coverage_report_step_part_collect_get_log_file(ngs_mapping_workflow):
+    """Tests TargetCoverageReportStepPart.get_log_file() - collect"""
+    expected = "work/target_cov_report/log/snakemake.target_coverage.log"
+    assert ngs_mapping_workflow.get_log_file("target_coverage_report", "collect") == expected
+
+
+def test_target_coverage_report_step_part_get_resource(ngs_mapping_workflow):
+    """Tests TargetCoverageReportStepPart.get_resource()"""
+    # Define expected
+    actions = ("run", "collect")
+    expected_dict = {"threads": 2, "time": "04:00:00", "memory": "20G", "partition": "medium"}
+    # Evaluate
+    for action in actions:
+        for resource, expected in expected_dict.items():
+            msg_error = f"Assertion error for resource '{resource}' in action '{action}'."
+            actual = ngs_mapping_workflow.get_resource("target_coverage_report", action, resource)
+            assert actual == expected, msg_error
+
+
+# Tests for GenomeCoverageReportStepPart ----------------------------------------------------------
+
+
+def test_genome_coverage_report_step_part_get_input_files(ngs_mapping_workflow):
+    """Tests GenomeCoverageReportStepPart.get_input_files()"""
+    # Define expected
+    expected = {
+        "bam": "work/{mapper_lib}/out/{mapper_lib}.bam",
+        "bai": "work/{mapper_lib}/out/{mapper_lib}.bam.bai",
+    }
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_input_files("genome_coverage_report", "run")
+    assert actual == expected
+
+
+def test_genome_coverage_report_step_part_get_output_files(ngs_mapping_workflow):
+    """Tests GenomeCoverageReportStepPart.get_output_files()"""
+    # Define expected
+    expected = {
+        "bed": "work/{mapper_lib}/report/coverage/{mapper_lib}.bed.gz",
+        "tbi": "work/{mapper_lib}/report/coverage/{mapper_lib}.bed.gz.tbi",
+    }
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_output_files("genome_coverage_report", "run")
+    assert actual == expected
+
+
+def test_genome_coverage_report_step_part_get_log_file(ngs_mapping_workflow):
+    """Tests GenomeCoverageReportStepPart.get_log_file()"""
+    # Define expected
+    expected = "work/{mapper_lib}/log/snakemake.genome_coverage.log"
+    # Get actual and assert
+    actual = ngs_mapping_workflow.get_log_file("genome_coverage_report", "run")
+    assert actual == expected
+
+
+def test_genome_coverage_report_step_part_get_shell_cmd(ngs_mapping_workflow):
+    """Tests GenomeCoverageReportStepPart.get_shell_cmd()"""
+    cmd = ngs_mapping_workflow.get_shell_cmd("genome_coverage_report", "run", None)
+    # The shell command returns a static blob and thus we only check for some important keywords.
+    # The actual functionality has to be tested in an integration/system test.
+    assert "samtools depth" in cmd
+    assert "bgzip -c" in cmd
+    assert "tabix {output.bed}" in cmd
+
+
+def test_genome_coverage_report_step_part_get_resource(ngs_mapping_workflow):
+    """Tests GenomeCoverageReportStepPart.get_resource()"""
+    # Define expected
+    expected_dict = {"threads": 1, "time": "04:00:00", "memory": "4G", "partition": "medium"}
+    # Evaluate
+    for resource, expected in expected_dict.items():
+        msg_error = f"Assertion error for resource '{resource}'."
+        actual = ngs_mapping_workflow.get_resource("genome_coverage_report", "run", resource)
+        assert actual == expected, msg_error
+
+
+# Tests for NgsMappingWorkflow --------------------------------------------------------------------
+
+
+def test_ngs_mapping_workflow_steps(ngs_mapping_workflow):
+    """Tests simple functionality of the workflow: checks if sub steps are created,
+    i.e., the tools associated with gene expression quantification."""
+    # Check created sub steps
+    expected = [
+        "bam_collect_doc",
+        "bwa",
+        "external",
+        "gatk_post_bam",
+        "genome_coverage_report",
+        "link_in",
+        "link_out",
+        "link_out_bam",
+        "minimap2",
+        "ngmlr",
+        "picard_hs_metrics",
+        "star",
+        "target_coverage_report",
+    ]
+    actual = list(sorted(ngs_mapping_workflow.sub_steps.keys()))
+    assert actual == expected
+
+
+def test_ngs_mapping_workflow_files(ngs_mapping_workflow):
+    """Tests simple functionality of the workflow: checks if file structure is created according
+    to the expected results from the tools, namely: bwa, external, gatk_post_bam,
+    genome_coverage_report, link_in, link_out, link_out_bam, minimap2, ngmlr, picard_hs_metrics,
+    star, target_coverage_report."""
+    # Check result file construction
+    expected = [
+        "output/bwa.P00{i}-N1-DNA1-WGS1/out/bwa.P00{i}-N1-DNA1-WGS1.{ext}".format(i=i, ext=ext)
+        for i in range(1, 7)
+        for ext in ("bam", "bam.bai", "bam.md5", "bam.bai.md5")
+    ]
+    expected += [
+        "output/bwa.P00{i}-N1-DNA1-WGS1/log/bwa.P00{i}-N1-DNA1-WGS1.{ext}".format(i=i, ext=ext)
+        for i in range(1, 7)
+        for ext in (
+            "log",
+            "conda_info.txt",
+            "conda_list.txt",
+            "log.md5",
+            "conda_info.txt.md5",
+            "conda_list.txt.md5",
+        )
+    ]
+    bam_stats_text_out = (
+        "output/bwa.P00{i}-N1-DNA1-WGS1/report/bam_qc/bwa.P00{i}-N1-DNA1-WGS1.bam.{stats}.{ext}"
+    )
+    expected += [
+        bam_stats_text_out.format(i=i, stats=stats, ext=ext)
+        for ext in ("txt", "txt.md5")
+        for i in range(1, 7)
+        for stats in ("bamstats", "flagstats", "idxstats")
+    ]
+    bam_stats_html_out = (
+        "output/bwa.P00{i}-N1-DNA1-WGS1/report/bam_qc/bwa.P00{i}-N1-DNA1-WGS1.bam.bamstats.{ext}"
+    )
+    expected += [
+        bam_stats_html_out.format(i=i, ext=ext) for ext in ("html", "html.md5") for i in range(1, 7)
+    ]
+    expected += [
+        "output/bwa.P00{i}-N1-DNA1-WGS1/report/cov/bwa.P00{i}-N1-DNA1-WGS1.cov.{ext}".format(
+            i=i, ext=ext
+        )
+        for ext in ("bw", "bw.md5", "vcf.gz", "vcf.gz.md5", "vcf.gz.tbi", "vcf.gz.tbi.md5")
+        for i in range(1, 7)
+    ]
+    expected += [
+        "output/bwa.P00{i}-N1-DNA1-WGS1/report/cov_qc/bwa.P00{i}-N1-DNA1-WGS1.{ext}".format(
+            i=i, ext=ext
+        )
+        for ext in ("txt", "txt.md5")
+        for i in range(1, 7)
+    ]
+    expected += [
+        "output/target_cov_report/out/target_cov_report.txt",
+        "output/target_cov_report/out/target_cov_report.txt.md5",
+    ]
+    expected += [
+        "output/bwa.P00{i}-N1-DNA1-WGS1/report/coverage/bwa.P00{i}-N1-DNA1-WGS1.{ext}".format(
+            i=i, ext=ext
+        )
+        for i in range(1, 7)
+        for ext in ("bed.gz", "bed.gz.tbi")
+    ]
+    assert sorted(ngs_mapping_workflow.get_result_files()) == sorted(expected)


### PR DESCRIPTION
closes #214 

**Important notes**

- the structure of the `output` directory is different from the other steps. The structure is `output/<tool>/<library>/out`. This is necessary as the step must produce `fastq` files that can be directly used by other steps (such as `ngs_mapping`).
- a `path_link_in` has been added to steps relying on `fastq` files for their input, through a modification of `LinkInPathGenerator`.