### PR TITLE
Bug fix: added missing env to wrapper bcf_to_vcf (#253)

### DIFF
--- a/snappy_wrappers/wrappers/bcftools/bcf_to_vcf/environment.yaml
+++ b/snappy_wrappers/wrappers/bcftools/bcf_to_vcf/environment.yaml
@@ -1,0 +1,1 @@
+../environment.yaml


### PR DESCRIPTION
Closes #253 