### PR TITLE
revert: not using parallel --workdir (#328)

### DIFF
--- a/snappy_wrappers/wrappers/bcftools/call_joint/wrapper.py
+++ b/snappy_wrappers/wrappers/bcftools/call_joint/wrapper.py
@@ -50,7 +50,6 @@ export PATH=$PATH:$(dirname $(dirname $(which conda)))/bin
 
 export TMPDIR=$(mktemp -d)
 trap "rm -rf $TMPDIR" EXIT
-mkdir -p $TMPDIR/parallel
 
 snappy-genome_windows \
     --fai-file $REF.fai \
@@ -58,7 +57,6 @@ snappy-genome_windows \
     {args_ignore_chroms} \
 | parallel \
     --plain \
-    --workdir $TMPDIR/parallel \
     --keep-order \
     --verbose \
     --max-procs {snakemake.config[step_config][somatic_variant_calling][bcftools_joint][num_threads]} \

--- a/snappy_wrappers/wrappers/bcftools_call/wrapper.py
+++ b/snappy_wrappers/wrappers/bcftools_call/wrapper.py
@@ -128,7 +128,7 @@ export -f run-shard
 mkdir -p $TMPDIR/parallel
 num_threads={snakemake.config[step_config][variant_calling][gatk4_hc_joint][num_threads]}
 cat $TMPDIR/final_intervals.txt \
-| parallel --plain --workdir $TMPDIR/parallel -j $num_threads 'run-shard {{#}} {{}}'
+| parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
 
 # Merge the individual shards' output VCF
 bcftools concat \

--- a/snappy_wrappers/wrappers/gatk3_hc/wrapper.py
+++ b/snappy_wrappers/wrappers/gatk3_hc/wrapper.py
@@ -111,7 +111,7 @@ export -f run-shard
 mkdir -p $TMPDIR/parallel
 num_threads={snakemake.config[step_config][variant_calling][gatk3_hc][num_threads]}
 cat $TMPDIR/final_intervals.txt \
-| parallel --plain --workdir $TMPDIR/parallel -j $num_threads 'run-shard {{#}} {{}}'
+| parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
 
 # Merge the individual shards' output VCF
 bcftools concat \

--- a/snappy_wrappers/wrappers/gatk3_ug/wrapper.py
+++ b/snappy_wrappers/wrappers/gatk3_ug/wrapper.py
@@ -112,7 +112,7 @@ export -f run-shard
 mkdir -p $TMPDIR/parallel
 num_threads={snakemake.config[step_config][variant_calling][gatk3_ug][num_threads]}
 cat $TMPDIR/final_intervals.txt \
-| parallel --plain --workdir $TMPDIR/parallel -j $num_threads 'run-shard {{#}} {{}}'
+| parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
 
 # Merge the individual shards' output VCF
 bcftools concat \

--- a/snappy_wrappers/wrappers/gatk4_hc/combine_gvcfs/wrapper.py
+++ b/snappy_wrappers/wrappers/gatk4_hc/combine_gvcfs/wrapper.py
@@ -113,7 +113,7 @@ export -f run-shard
 mkdir -p $TMPDIR/parallel
 num_threads={snakemake.config[step_config][variant_calling][gatk4_hc_gvcf][num_threads]}
 cat $TMPDIR/final_intervals.txt \
-| parallel --workdir $TMPDIR/parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
+| parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
 
 # Merge the individual shards' output VCF
 bcftools concat \

--- a/snappy_wrappers/wrappers/gatk4_hc/discover/wrapper.py
+++ b/snappy_wrappers/wrappers/gatk4_hc/discover/wrapper.py
@@ -116,7 +116,7 @@ export -f run-shard
 mkdir -p $TMPDIR/parallel
 num_threads={snakemake.config[step_config][variant_calling][gatk4_hc_gvcf][num_threads]}
 cat $TMPDIR/final_intervals.txt \
-| parallel --workdir $TMPDIR/parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
+| parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
 
 # Merge the individual shards' output VCF
 bcftools concat \

--- a/snappy_wrappers/wrappers/gatk4_hc/genotype/wrapper.py
+++ b/snappy_wrappers/wrappers/gatk4_hc/genotype/wrapper.py
@@ -109,7 +109,7 @@ export -f run-shard
 mkdir -p $TMPDIR/parallel
 num_threads={snakemake.config[step_config][variant_calling][gatk4_hc_gvcf][num_threads]}
 cat $TMPDIR/final_intervals.txt \
-| parallel --workdir $TMPDIR/parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
+| parallel --plain -j $num_threads 'run-shard {{#}} {{}}'
 
 # Merge the individual shards' output VCF
 bcftools concat \

--- a/snappy_wrappers/wrappers/gatk4_hc/joint/wrapper.py
+++ b/snappy_wrappers/wrappers/gatk4_hc/joint/wrapper.py
@@ -111,10 +111,9 @@ run-shard()
 export -f run-shard
 
 # Perform parallel execution
-mkdir -p $TMPDIR/parallel
 num_threads={snakemake.config[step_config][variant_calling][gatk4_hc_joint][num_threads]}
 cat $TMPDIR/final_intervals.txt \
-| parallel --plain --workdir $TMPDIR/parallel -j $num_threads 'run-shard {{#}} {{}}'
+| parallel -j $num_threads 'run-shard {{#}} {{}}'
 
 # Merge the individual shards' output VCF
 bcftools concat \

--- a/snappy_wrappers/wrappers/varscan/call_joint/wrapper.py
+++ b/snappy_wrappers/wrappers/varscan/call_joint/wrapper.py
@@ -108,12 +108,10 @@ generate_intervals()
 }}
 
 
-mkdir -p $TMPDIR/parallel
 for vartype in snp indel; do
     generate_intervals \
     | parallel \
         --plain \
-        --workdir $TMPDIR/parallel
         --keep-order \
         --verbose \
         --max-procs {snakemake.config[step_config][somatic_variant_calling][varscan_joint][num_cores]} \


### PR DESCRIPTION
This actually overrides TMPDIR in the called bash functions.