### PR TITLE
fix: solve issues with variant_export_external and re-enable wgs_cnv_export_external

### DIFF
--- a/snappy_pipeline/apps/snappy_snake.py
+++ b/snappy_pipeline/apps/snappy_snake.py
@@ -58,6 +58,7 @@ from ..workflows import (
     variant_filtration,
     variant_phasing,
     wgs_sv_export_external,
+    wgs_cnv_export_external,
 )
 
 __author__ = "Manuel Holtgrewe <manuel.holtgrewe@bih-charite.de>"
@@ -111,6 +112,7 @@ STEP_TO_MODULE = {
     "variant_filtration": variant_filtration,
     "variant_phasing": variant_phasing,
     "wgs_sv_export_external": wgs_sv_export_external,
+    "wgs_cnv_export_external": wgs_cnv_export_external,
 }
 
 

--- a/snappy_pipeline/apps/snappy_snake.py
+++ b/snappy_pipeline/apps/snappy_snake.py
@@ -57,8 +57,8 @@ from ..workflows import (
     variant_export_external,
     variant_filtration,
     variant_phasing,
-    wgs_sv_export_external,
     wgs_cnv_export_external,
+    wgs_sv_export_external,
 )
 
 __author__ = "Manuel Holtgrewe <manuel.holtgrewe@bih-charite.de>"
@@ -111,8 +111,8 @@ STEP_TO_MODULE = {
     "variant_export_external": variant_export_external,
     "variant_filtration": variant_filtration,
     "variant_phasing": variant_phasing,
-    "wgs_sv_export_external": wgs_sv_export_external,
     "wgs_cnv_export_external": wgs_cnv_export_external,
+    "wgs_sv_export_external": wgs_sv_export_external,
 }
 
 

--- a/snappy_pipeline/workflows/variant_export_external/__init__.py
+++ b/snappy_pipeline/workflows/variant_export_external/__init__.py
@@ -154,6 +154,13 @@ class BamReportsExternalStepPart(TargetCoverageReportStepPart):
         yield f"work/input_links/{wildcards.library_name}/.done_bam_external"
         yield f"work/input_links/{wildcards.library_name}/.done_bai_external"
 
+    @dictify
+    def get_output_files(self, action):
+        """Return output files"""
+        result = super().get_output_files(action)
+        result["output_links"] = []
+        yield from result.items()
+
     @listify
     def _get_input_files_collect(self, wildcards):
         _ = wildcards
@@ -361,10 +368,15 @@ class VarfishAnnotatorAnnotateStepPart(BaseStepPart):
         prefix = (
             "work/varfish_annotated.{index_ngs_library}/out/varfish_annotated.{index_ngs_library}"
         )
+        paths_work = {}
         for infix in ("gts", "db-infos"):
             key = infix.replace("-", "_")
-            yield key, prefix + f".{infix}.tsv.gz"
-            yield key + "_md5", prefix + f".{infix}.tsv.gz.md5"
+            paths_work[key] = prefix + f".{infix}.tsv.gz"
+            paths_work[key + "_md5"] = prefix + f".{infix}.tsv.gz.md5"
+        paths_work["ped"] = f"{prefix}.ped"
+        paths_work["ped_md5"] = f"{prefix}.ped.md5"
+        yield from paths_work.items()
+        yield "output_links", []
 
     @dictify
     def _get_output_files_bam_qc(self):
@@ -374,6 +386,7 @@ class VarfishAnnotatorAnnotateStepPart(BaseStepPart):
         )
         yield key, prefix + ".bam-qc.tsv.gz"
         yield key + "_md5", prefix + ".bam-qc.tsv.gz.md5"
+        yield "output_links", []
 
     @dictify
     def get_log_file(self, action):
@@ -391,14 +404,14 @@ class VarfishAnnotatorAnnotateStepPart(BaseStepPart):
         )
         key_ext = (
             ("log", ".log"),
-            ("log_md5", ".log.md5"),
             ("conda_info", ".conda_info.txt"),
-            ("conda_info_md5", ".conda_info.txt.md5"),
             ("conda_list", ".conda_list.txt"),
-            ("conda_list_md5", ".conda_list.txt.md5"),
+            ("wrapper", ".wrapper.py"),
+            ("env_yaml", ".environment.yaml"),
         )
         for key, ext in key_ext:
             yield key, prefix + ext
+            yield key + "_md5", prefix + ext + ".md5"
 
     @staticmethod
     @dictify
@@ -408,10 +421,11 @@ class VarfishAnnotatorAnnotateStepPart(BaseStepPart):
             f"varfish_annotated.{action}.{{index_ngs_library}}"
         )
         key_ext = (
-            ("wrapper", ".wrapper.py"),
             ("log", ".log"),
             ("conda_info", ".conda_info.txt"),
             ("conda_list", ".conda_list.txt"),
+            ("wrapper", ".wrapper.py"),
+            ("env_yaml", ".environment.yaml"),
         )
         for key, ext in key_ext:
             yield key, prefix + ext
@@ -623,6 +637,10 @@ class VariantExportExternalWorkflow(BaseStep):
                     ".conda_info.txt.md5",
                     ".conda_list.txt",
                     ".conda_list.txt.md5",
+                    ".wrapper.py",
+                    ".wrapper.py.md5",
+                    ".environment.yaml",
+                    ".environment.yaml.md5",
                 ),
             )
 

--- a/snappy_wrappers/wrappers/varfish_annotator/annotate/wrapper.py
+++ b/snappy_wrappers/wrappers/varfish_annotator/annotate/wrapper.py
@@ -5,7 +5,8 @@ from snakemake.shell import shell
 __author__ = "Manuel Holtgrewe <manuel.holtgrewe@bih-charite.de>"
 
 # Get shortcut to configuration of varfish_export step
-export_config = snakemake.config["step_config"]["varfish_export"]
+step_name = snakemake.params.args["step_name"]
+export_config = snakemake.config["step_config"][step_name]
 
 DEF_HELPER_FUNCS = r"""
 compute-md5()

--- a/tests/snappy_pipeline/workflows/test_workflows_variant_export_external.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_variant_export_external.py
@@ -223,20 +223,7 @@ def test_bam_reports_step_part_call_get_output_files_bam_qc(
         "flagstats_md5": "work/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.flagstats.txt.md5",
         "idxstats": "work/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.idxstats.txt",
         "idxstats_md5": "work/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.idxstats.txt.md5",
-        "output_links": [
-            "output/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.bamstats.txt",
-            "output/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.bamstats.txt.md5",
-            "output/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.flagstats.txt",
-            "output/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.flagstats.txt.md5",
-            "output/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.idxstats.txt",
-            "output/{mapper}.{library_name}/report/bam_qc/{mapper}.{library_name}.bam.idxstats.txt.md5",
-            "output/{mapper}.{library_name}/log/{mapper}.{library_name}.bam_qc.log",
-            "output/{mapper}.{library_name}/log/{mapper}.{library_name}.bam_qc.log.md5",
-            "output/{mapper}.{library_name}/log/{mapper}.{library_name}.bam_qc.conda_info.txt",
-            "output/{mapper}.{library_name}/log/{mapper}.{library_name}.bam_qc.conda_info.txt.md5",
-            "output/{mapper}.{library_name}/log/{mapper}.{library_name}.bam_qc.conda_list.txt",
-            "output/{mapper}.{library_name}/log/{mapper}.{library_name}.bam_qc.conda_list.txt.md5",
-        ],
+        "output_links": [],
     }
     actual = variant_export_external_workflow.get_output_files("bam_reports", "bam_qc")
     assert actual == expected
@@ -342,7 +329,7 @@ def test_varfish_annotator_step_part_call_get_log_file_gvcf_to_vcf(
 ):
     """Tests VarfishAnnotatorExternalStepPart._get_log_file_gvcf_to_vcf()"""
     base_name = "work/dragen.{index_ngs_library}/log/dragen.{index_ngs_library}.gvcf_to_vcf"
-    expected = get_expected_log_files_dict(base_out=base_name)
+    expected = get_expected_log_files_dict(base_out=base_name, extended=True)
     actual = variant_export_external_workflow.get_log_file(
         "varfish_annotator_external", "gvcf_to_vcf"
     )
@@ -409,7 +396,7 @@ def test_varfish_annotator_step_part_call_get_output_files_merge_vcf(
 def test_varfish_annotator_step_part_call_get_log_file_merge_vcf(variant_export_external_workflow):
     """Tests VarfishAnnotatorExternalStepPart._get_log_file_merge_vcf()"""
     base_name = "work/dragen.{index_ngs_library}/log/dragen.{index_ngs_library}.merge_vcf"
-    expected = get_expected_log_files_dict(base_out=base_name)
+    expected = get_expected_log_files_dict(base_out=base_name, extended=True)
     actual = variant_export_external_workflow.get_log_file(
         "varfish_annotator_external", "merge_vcf"
     )
@@ -472,6 +459,9 @@ def test_varfish_annotator_step_part_get_output_files_annotate(variant_export_ex
         "gts_md5": base_name_out + ".gts.tsv.gz.md5",
         "db_infos": base_name_out + ".db-infos.tsv.gz",
         "db_infos_md5": base_name_out + ".db-infos.tsv.gz.md5",
+        "ped": base_name_out + ".ped",
+        "ped_md5": base_name_out + ".ped.md5",
+        "output_links": [],
     }
     # Get actual
     actual = variant_export_external_workflow.get_output_files(
@@ -495,7 +485,7 @@ def test_varfish_annotator_step_part_get_log_file_annotate(variant_export_extern
         "wrapper": base_name_wrapper + ".wrapper.py",
         "wrapper_md5": base_name_wrapper + ".wrapper.py.md5",
     }
-    log_dict = get_expected_log_files_dict(base_out=base_name_log)
+    log_dict = get_expected_log_files_dict(base_out=base_name_log, extended=True)
     expected = {**wrapper_dict, **log_dict}
     # Get actual
     actual = variant_export_external_workflow.get_log_file("varfish_annotator_external", "annotate")
@@ -561,6 +551,7 @@ def test_varfish_annotator_step_part_get_output_files_bam_qc(variant_export_exte
     expected = {
         "bam_qc": base_name_out + ".bam-qc.tsv.gz",
         "bam_qc_md5": base_name_out + ".bam-qc.tsv.gz.md5",
+        "output_links": [],
     }
     # Get actual
     actual = variant_export_external_workflow.get_output_files(
@@ -584,7 +575,7 @@ def test_varfish_annotator_step_part_get_log_file_bam_qc(variant_export_external
         "wrapper": base_name_wrapper + ".wrapper.py",
         "wrapper_md5": base_name_wrapper + ".wrapper.py.md5",
     }
-    log_dict = get_expected_log_files_dict(base_out=base_name_log)
+    log_dict = get_expected_log_files_dict(base_out=base_name_log, extended=True)
     expected = {**wrapper_dict, **log_dict}
     # Get actual
     actual = variant_export_external_workflow.get_log_file("varfish_annotator_external", "bam_qc")
@@ -663,6 +654,10 @@ def test_variant_export_external_workflow(variant_export_external_workflow):
             "conda_info.txt.md5",
             "conda_list.txt",
             "conda_list.txt.md5",
+            "wrapper.py",
+            "wrapper.py.md5",
+            "environment.yaml",
+            "environment.yaml.md5",
         )
         for type_ in (".annotate", ".bam_qc")
     ]


### PR DESCRIPTION
re-enable wgs_cnv_export_external:
- the 'wgs_cnv_export_external' was removed from the snappy_snake app by accident. I has now been re-added

solve issues with variant_export_external:
- changes in the wrapper for varfish_annotator broke the 'variant_export_external' step, since it also relies on this. The expected log files and output links/files have been updated.