### PR TITLE
fix: remove "tar results" from manta wrappers

### DIFF
--- a/snappy_wrappers/wrappers/manta/germline_targeted/wrapper.py
+++ b/snappy_wrappers/wrappers/manta/germline_targeted/wrapper.py
@@ -76,10 +76,7 @@ python2 $workdir/runWorkflow.py \
 cp -ra $workdir/results $outdir
 rm -rf $workdir
 
-sleep 1m  # for good measure
-
 pushd $outdir
-tar czf results.tar.gz results
 ln -sr results/variants/diploidSV.vcf.gz $(basename {snakemake.output.vcf})
 ln -sr results/variants/diploidSV.vcf.gz.tbi $(basename {snakemake.output.vcf_tbi})
 ln -sr results/variants/candidateSV.vcf.gz \

--- a/snappy_wrappers/wrappers/manta/germline_wgs/wrapper.py
+++ b/snappy_wrappers/wrappers/manta/germline_wgs/wrapper.py
@@ -74,10 +74,7 @@ python2 $workdir/runWorkflow.py \
 cp -ra $workdir/results $outdir
 rm -rf $workdir
 
-sleep 1m  # for good measure
-
 pushd $outdir
-tar czf results.tar.gz results
 ln -sr results/variants/diploidSV.vcf.gz $(basename {snakemake.output.vcf})
 ln -sr results/variants/diploidSV.vcf.gz.tbi $(basename {snakemake.output.vcf_tbi})
 ln -sr results/variants/candidateSV.vcf.gz \

--- a/snappy_wrappers/wrappers/manta/somatic_wgs/wrapper.py
+++ b/snappy_wrappers/wrappers/manta/somatic_wgs/wrapper.py
@@ -36,7 +36,6 @@ cp -ra $workdir/results $outdir
 rm -rf $workdir
 
 pushd $outdir
-tar czf results.tar.gz results
 ln -sr results/variants/somaticSV.vcf.gz $(basename {snakemake.output.vcf})
 ln -sr results/variants/somaticSV.vcf.gz.tbi $(basename {snakemake.output.vcf_tbi})
 ln -sr results/variants/candidateSV.vcf.gz \


### PR DESCRIPTION
The data was never looked at and for some reason the files keep changing after manta terminates (maybe a disowned cleanup job?)