### PR TITLE
feat: path_exon_bed can be provided independent of data type (#389)

### DIFF
--- a/snappy_pipeline/workflows/varfish_export/__init__.py
+++ b/snappy_pipeline/workflows/varfish_export/__init__.py
@@ -119,8 +119,8 @@ step_config:
     #
     # The release of the genome reference that data has been aligned to.
     release: GRCh37              # REQUIRED: default 'GRCh37'
-    # Path to BED file with exons; used for reducing WGS data to near-exon small variants.
-    path_exon_bed: REQUIRED      # REQUIRED: exon BED file to use when handling WGS data
+    # Path to BED file with exons; used for reducing data to near-exon small variants.
+    path_exon_bed: null          # REQUIRED: exon BED file to use
     # Path to Jannovar RefSeq ``.ser`` file for annotation
     path_refseq_ser: REQUIRED    # REQUIRED: path to RefSeq .ser file
     # Path to Jannovar ENSEMBL ``.ser`` file for annotation
@@ -299,8 +299,8 @@ class VarfishAnnotatorAnnotateStepPart(VariantCallingGetLogFileMixin, BaseStepPa
                 donor.dna_ngs_library
                 and donor.dna_ngs_library.extra_infos.get("libraryType") == "WGS"
             ):
-                return {"is_wgs": True, "step_name": "varfish_export"}
-        return {"is_wgs": False, "step_name": "varfish_export"}
+                return {"step_name": "varfish_export"}
+        return {"step_name": "varfish_export"}
 
     @dictify
     def _get_input_files_annotate_svs(self, wildcards):

--- a/snappy_pipeline/workflows/variant_export_external/__init__.py
+++ b/snappy_pipeline/workflows/variant_export_external/__init__.py
@@ -109,7 +109,8 @@ step_config:
     search_paths: []             # REQUIRED: list of paths to VCF files.
     search_patterns: []          # REQUIRED: list of search patterns, ex.: [{"vcf": "*.vcf.gz"}, {"bam": "*.bam"}, {"bai": "*.bam.bai"}]
     release: GRCh37              # OPTIONAL: genome release; default 'GRCh37'.
-    path_exon_bed: REQUIRED      # OPTIONAL: exon BED file to use when handling WGS data.
+    # Path to BED file with exons; used for reducing data to near-exon small variants.
+    path_exon_bed: null          # REQUIRED: exon BED file to use
     path_refseq_ser: REQUIRED    # REQUIRED: path to RefSeq .ser file.
     path_ensembl_ser: REQUIRED   # REQUIRED: path to ENSEMBL .ser file.
     path_db: REQUIRED            # REQUIRED: path to annotator DB file to use.
@@ -479,8 +480,8 @@ class VarfishAnnotatorAnnotateStepPart(BaseStepPart):
                 donor.dna_ngs_library
                 and donor.dna_ngs_library.extra_infos.get("libraryType") == "WGS"
             ):
-                return {"is_wgs": True, "step_name": "variant_export_external"}
-        return {"is_wgs": False, "step_name": "variant_export_external"}
+                return {"step_name": "variant_export_external"}
+        return {"step_name": "variant_export_external"}
 
     def _get_params_bam_qc(self, wildcards):
         """Get parameters for wrapper ``variant_annotator/bam_qc``

--- a/snappy_pipeline/workflows/wgs_cnv_export_external/__init__.py
+++ b/snappy_pipeline/workflows/wgs_cnv_export_external/__init__.py
@@ -272,20 +272,10 @@ class VarfishAnnotatorExternalStepPart(BaseStepPart):
 
     def _get_params_annotate(self, wildcards):
         varfish_server_compatibility_flag = self.config["varfish_server_compatibility"]
-        result = {
-            "is_wgs": True,
+        return {
             "step_name": "wgs_cnv_export_external",
             "varfish_server_compatibility": varfish_server_compatibility_flag,
         }
-        pedigree = self.index_ngs_library_to_pedigree[wildcards.index_ngs_library]
-        for donor in pedigree.donors:
-            if (
-                donor.dna_ngs_library
-                and donor.dna_ngs_library.extra_infos.get("libraryType") == "WGS"
-            ):
-                result["is_wgs"] = True
-                return result
-        return result
 
     def _collect_vcfs(self, wildcards):
         """Yield path to pedigree VCF"""

--- a/snappy_pipeline/workflows/wgs_sv_export_external/__init__.py
+++ b/snappy_pipeline/workflows/wgs_sv_export_external/__init__.py
@@ -271,20 +271,10 @@ class VarfishAnnotatorExternalStepPart(BaseStepPart):
         return result
 
     def _get_params_annotate(self, wildcards):
-        result = {
-            "is_wgs": True,
+        return {
             "step_name": "wgs_sv_export_external",
             "varfish_server_compatibility": self.config["varfish_server_compatibility"],
         }
-        pedigree = self.index_ngs_library_to_pedigree[wildcards.index_ngs_library]
-        for donor in pedigree.donors:
-            if (
-                donor.dna_ngs_library
-                and donor.dna_ngs_library.extra_infos.get("libraryType") == "WGS"
-            ):
-                result["is_wgs"] = True
-                return result
-        return result
 
     def _collect_vcfs(self, wildcards):
         """Yield path to pedigree VCF"""

--- a/snappy_wrappers/wrappers/varfish_annotator/annotate/wrapper.py
+++ b/snappy_wrappers/wrappers/varfish_annotator/annotate/wrapper.py
@@ -58,8 +58,8 @@ trap "rm -rf $TMPDIR" EXIT
 
 # Run actual tools --------------------------------------------------------------------------------
 
-# For WGS, extract around exon BED file
-if [[ {snakemake.params.args[is_wgs]} == True ]]; then
+# Extract around BED file, if given.
+if [[ -n "{export_config[path_exon_bed]}" ]] && [[ "{export_config[path_exon_bed]}" != "None" ]]; then
     set -e
     bcftools view \
         -R {export_config[path_exon_bed]} \

--- a/tests/snappy_pipeline/workflows/test_workflows_varfish_export.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_varfish_export.py
@@ -260,7 +260,7 @@ def test_varfish_annotator_step_part_get_log_file_bam_qc(varfish_export_workflow
 def test_varfish_annotator_step_part_get_params_annotate(varfish_export_workflow):
     """Tests VarfishAnnotatorAnnotateStepPart._get_params_annotate()"""
     wildcards = Wildcards(fromdict={"index_ngs_library": "P001-N1-DNA1-WGS1"})
-    expected = {"is_wgs": True, "step_name": "varfish_export"}
+    expected = {"step_name": "varfish_export"}
     actual = varfish_export_workflow.get_params("varfish_annotator", "annotate")(wildcards)
     assert actual == expected
 

--- a/tests/snappy_pipeline/workflows/test_workflows_variant_export_external.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_variant_export_external.py
@@ -495,7 +495,7 @@ def test_varfish_annotator_step_part_get_log_file_annotate(variant_export_extern
 def test_varfish_annotator_step_part_get_params_annotate(variant_export_external_workflow):
     """Tests VarfishAnnotatorAnnotateStepPart._get_params_annotate()"""
     wildcards = Wildcards(fromdict={"index_ngs_library": "P001-N1-DNA1-WGS1"})
-    expected = {"is_wgs": True, "step_name": "variant_export_external"}
+    expected = {"step_name": "variant_export_external"}
     actual = variant_export_external_workflow.get_params("varfish_annotator_external", "annotate")(
         wildcards
     )

--- a/tests/snappy_pipeline/workflows/test_workflows_wgs_cnv_export_external.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_wgs_cnv_export_external.py
@@ -316,7 +316,6 @@ def test_varfish_annotator_step_part_get_params_annotate(wgs_cnv_export_external
     """Tests VarfishAnnotatorAnnotateStepPart._get_params_annotate()"""
     wildcards = Wildcards(fromdict={"index_ngs_library": "P001-N1-DNA1-WGS1"})
     expected = {
-        "is_wgs": True,
         "step_name": "wgs_cnv_export_external",
         "varfish_server_compatibility": False,
     }

--- a/tests/snappy_pipeline/workflows/test_workflows_wgs_sv_export_external.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_wgs_sv_export_external.py
@@ -316,7 +316,6 @@ def test_varfish_annotator_step_part_get_params_annotate(wgs_sv_export_external_
     """Tests VarfishAnnotatorAnnotateStepPart_.get_params_annotate()"""
     wildcards = Wildcards(fromdict={"index_ngs_library": "P001-N1-DNA1-WGS1"})
     expected = {
-        "is_wgs": True,
         "step_name": "wgs_sv_export_external",
         "varfish_server_compatibility": False,
     }


### PR DESCRIPTION
Previously, the BED file value was always used for WGS data and never used for WES data.  Now, it is used when it has been provided (not the empty string and not null/None).

CC @xiamaz