### PR TITLE
fix: update snakemake version requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ biomedsheets >=0.11.7
 termcolor==1.1.0
 
 # Snakemake is used for providing the actual wrapper calling functionality
-snakemake >=7.24.1
+snakemake >=7.24.1,<=7.26
 # Snakemake needs manual install of PyYAML to make YAML configuration loading work
 PyYAML>=6.0
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ biomedsheets >=0.11.7
 termcolor==1.1.0
 
 # Snakemake is used for providing the actual wrapper calling functionality
-snakemake >=7.24.1,<=7.26
+snakemake==7.26.0
 # Snakemake needs manual install of PyYAML to make YAML configuration loading work
 PyYAML>=6.0
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ biomedsheets >=0.11.7
 termcolor==1.1.0
 
 # Snakemake is used for providing the actual wrapper calling functionality
-snakemake >=7.8.0
+snakemake >=7.24.1
 # Snakemake needs manual install of PyYAML to make YAML configuration loading work
 PyYAML>=6.0
 


### PR DESCRIPTION
This fixes #396, as snakemake versions between `7.20` and `7.24.0` introduced a bug that caused python version detection to crash on any version without f-strings (which were introduced in py36).

This also adds an upper limit on the last known-working snakemake version, which should only be manually incremented.