### PR TITLE
feat: 438 vep annotation order

### DIFF
--- a/snappy_pipeline/workflows/cbioportal_export/__init__.py
+++ b/snappy_pipeline/workflows/cbioportal_export/__init__.py
@@ -5,9 +5,6 @@ This step takes as input a wide range of files previously produced by the
 snappy_pipeline. It does the necessary data transformations to comply with the
 formats expected by cBioPortal and writes out the necessary metadata and data
 files.
-
-The output is a archive (tarball) that can be uploaded to a cbioportal instance
-for import.
 """
 
 from collections import OrderedDict
@@ -436,11 +433,11 @@ class cbioportalCnaFilesStepPart(cbioportalExportStepPart):
     def get_args(self, action):
         # Validate action
         self._validate_action(action)
-        if action == "gistic":
-            return {"action_type": "gistic", "extra_args": {"pipeline_id": "ENSEMBL"}}
         if action == "log2":
+            return {"action_type": "log2", "extra_args": {"pipeline_id": "ENSEMBL"}}
+        if action == "gistic":
             return {
-                "action_type": "log2",
+                "action_type": "gistic",
                 "extra_args": {
                     "pipeline_id": "ENSEMBL",
                     "amplification": "9",

--- a/snappy_pipeline/workflows/somatic_variant_annotation/Snakefile
+++ b/snappy_pipeline/workflows/somatic_variant_annotation/Snakefile
@@ -92,7 +92,7 @@ rule somatic_variant_annotation_jannovar_annotate_somatic_vcf:
     log:
         **wf.get_log_file("jannovar", "annotate_somatic_vcf"),
     wrapper:
-        wf.wrapper_path("jannovar_par/annotate_somatic_vcf")
+        wf.wrapper_path("jannovar/annotate_somatic_vcf")
 
 
 # Variant Statistics Computation ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/snappy_pipeline/workflows/somatic_variant_annotation/__init__.py
+++ b/snappy_pipeline/workflows/somatic_variant_annotation/__init__.py
@@ -26,7 +26,31 @@ The variant annotation step uses Snakemake sub workflows for using the result of
 Step Output
 ===========
 
-TODO
+Annotations can be done on all genes & transcripts overlapping with the variant locus, or
+they can select one representative gene and transcript for annotation.
+In the latter case, the output vcf file will only contain one annotation per variant, while
+in the former case, there might be over 100 annotations for each variant.
+
+The ordering of features drinving the representative annotation choice is under user control.
+The default order is:
+
+1. ``biotype``: protein coding genes come first, it is unclear what is the order for other types of genes
+2. ``mane``: the `MANE transcript <https://www.ncbi.nlm.nih.gov/refseq/MANE/>`_ is selected before other transcripts
+3. ``appris``: the `APPRIS principal isoform <https://academic.oup.com/bioinformatics/article/38/Supplement_2/ii89/6701991>`_ is selected before alternates
+4. ``tsl``: `Transcript Support Level <http://www.ensembl.org/info/genome/genebuild/transcript_quality_tags.html>`_ values in increasing order
+5. ``ccds``: Transcripts with `CCDS <https://www.ncbi.nlm.nih.gov/projects/CCDS/CcdsBrowse.cgi>`_ ids are selected before those without
+6. ``canonical``: ENSEMBL canonical transcripts are selected before the others
+7. ``rank``: VEP internal ranking is used
+8. ``length``: longer transcripts are preferred to shorter ones
+
+This order is (hopefully) suitable for cBioPortal export, as well defined transcripts from protein-coding genes are selected when possible.
+However, it is recommended to check the full annotation for variants in or nearby disease-relevant genes.
+
+All annotators generate a vcf with one annotation per transcript, and some annotators
+(only ENSEMBL's Variant Effect Predictor in the current implementation) can also produce another
+output containing all annotations.
+The single annotation vcf is named ``<mapper>.<caller>.<annotator>.vcf.gz`` and
+the full annotation output is named ``<mapper>.<caller>.<annotator>.full.vcf.gz``
 
 ====================
 Global Configuration
@@ -115,7 +139,7 @@ step_config:
       assembly: GRCh38
       cache_version: 102        # WARNING- this must match the wrapper's vep version!
       tx_flag: "gencode_basic"  # The flag selecting the transcripts.  One of "gencode_basic", "refseq", and "merged".
-      pick: yes                 # Other option: no (report one or all consequences)
+      pick_order: ["biotype", "mane", "appris", "tsl", "ccds", "canonical", "rank", "length"]
       num_threads: 8
       buffer_size: 1000
       output_options:
@@ -130,6 +154,9 @@ class AnnotateSomaticVcfStepPart(BaseStepPart):
 
         The ``tumor_library`` wildcard can actually be the name of a donor!
     """
+
+    #: Only creates vcf with one annotation per variant
+    has_full = False
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -169,6 +196,9 @@ class AnnotateSomaticVcfStepPart(BaseStepPart):
             "{{mapper}}.{{var_caller}}.{annotator}.{{tumor_library}}"
         ).format(annotator=self.annotator)
         key_ext = {"vcf": ".vcf.gz", "vcf_tbi": ".vcf.gz.tbi"}
+        if self.has_full:
+            key_ext["full"] = ".full.vcf.gz"
+            key_ext["full_tbi"] = ".full.vcf.gz.tbi"
         for key, ext in key_ext.items():
             yield key, prefix + ext
             yield key + "_md5", prefix + ext + ".md5"
@@ -261,6 +291,12 @@ class VepAnnotateSomaticVcfStepPart(AnnotateSomaticVcfStepPart):
     #: Class available actions
     actions = ("run",)
 
+    #: Also creates vcf with all annotations
+    has_full = True
+
+    #: Allowed keywords for pick order
+    PICK_ORDER = ("biotype", "mane", "appris", "tsl", "ccds", "canonical", "rank", "length")
+
     def get_resource_usage(self, action):
         """Get Resource Usage
 
@@ -282,8 +318,10 @@ class VepAnnotateSomaticVcfStepPart(AnnotateSomaticVcfStepPart):
             return
         if not self.config["vep"]["tx_flag"] in ("merged", "refseq", "gencode_basic"):
             raise InvalidConfiguration("tx_flag must be 'gencode_basic', or 'merged' or 'refseq'")
-        if not self.config["vep"]["pick"] in ("yes", "no"):
-            raise InvalidConfiguration("pick must be either 'yes' or 'no'")
+        if not all([x in self.PICK_ORDER for x in self.config["vep"]["pick_order"]]):
+            raise InvalidConfiguration(
+                "pick order keywords must be in {}".format(", ".join(self.PICK_ORDER))
+            )
 
 
 class SomaticVariantAnnotationWorkflow(BaseStep):
@@ -361,6 +399,23 @@ class SomaticVariantAnnotationWorkflow(BaseStep):
                 ".conda_list.txt",
                 ".conda_list.txt.md5",
             ),
+        )
+        # Annotators with full output
+        full = list(
+            map(
+                lambda x: x.replace("jannovar", "jannovar_annotate_somatic_vcf"),
+                filter(
+                    lambda x: self.sub_steps[x].has_full,
+                    set(self.config["tools"]) & set(ANNOTATION_TOOLS),
+                ),
+            )
+        )
+        yield from self._yield_result_files_matched(
+            os.path.join("output", name_pattern, "out", name_pattern + ".full{ext}"),
+            mapper=self.config["tools_ngs_mapping"],
+            caller=callers & set(SOMATIC_VARIANT_CALLERS_MATCHED),
+            annotator=full,
+            ext=EXT_VALUES,
         )
         # joint calling
         name_pattern = "{mapper}.{caller}.{annotator}.{donor.name}"

--- a/snappy_pipeline/workflows/somatic_variant_annotation/__init__.py
+++ b/snappy_pipeline/workflows/somatic_variant_annotation/__init__.py
@@ -26,12 +26,12 @@ The variant annotation step uses Snakemake sub workflows for using the result of
 Step Output
 ===========
 
-Annotations can be done on all genes & transcripts overlapping with the variant locus, or
+Users can annotate all genes & transcripts overlapping with the variant locus, or
 they can select one representative gene and transcript for annotation.
 In the latter case, the output vcf file will only contain one annotation per variant, while
 in the former case, there might be over 100 annotations for each variant.
 
-The ordering of features drinving the representative annotation choice is under user control.
+The ordering of features driving the representative annotation choice is under user control.
 The default order is:
 
 1. ``biotype``: protein coding genes come first, it is unclear what is the order for other types of genes

--- a/snappy_wrappers/wrappers/cbioportal/merge_tables/script.R
+++ b/snappy_wrappers/wrappers/cbioportal/merge_tables/script.R
@@ -37,13 +37,13 @@ merge_tables <- function(fns, mappings, type=c("log2", "gistic", "segment", "exp
     }
 
     if (type == "gistic") {
-        stopifnot(all(c("pipeline_id") %in% names(args)))
+        stopifnot(all(c("pipeline_id", "amplification") %in% names(args)))
         # Copy numbers (in "cn" column) are transformed into (pseudo-) gistic codes:
         # 0: Deep deletion, 1: heterozygous deletion, 2: copy number neutral, 3: gain, 4: amplification
         # In https://doi.org/10.1038/s41586-022-04738-6, the amplification is defined as 
         # copy number greater or equal to 9 copies (args$amplification = 9).
         args$amplification <- as.numeric(args$amplification)
-        cn <- read_sample_files(fns, args$pipeline_id, "cn")
+        cn <- round(read_sample_files(fns, args$pipeline_id, "cn"))
         cn[args$amplification<=cn] <- args$amplification
         cn[2<cn & cn<args$amplification] <- 3
         cn[cn==args$amplification] <- 4
@@ -57,7 +57,7 @@ merge_tables <- function(fns, mappings, type=c("log2", "gistic", "segment", "exp
     }
 
     if (type == "log2") {
-        stopifnot(all(c("pipeline_id", "amplification") %in% names(args)))
+        stopifnot(all(c("pipeline_id") %in% names(args)))
         tmp <- read_sample_files(fns, args$pipeline_id, "log2")
         method <- "max"
     }
@@ -65,7 +65,6 @@ merge_tables <- function(fns, mappings, type=c("log2", "gistic", "segment", "exp
     if (remove_feature_version) rownames(tmp) <- sub("\\.[0-9]+$", "", rownames(tmp))
 
     rslt <- map_feature_id(tmp, mappings, from=args$pipeline_id, to="SYMBOL", method=method)
-    if (type == "gistic") rslt <- rslt+2
 
     rslt <- data.frame(
         Hugo_Symbol=rownames(rslt),

--- a/snappy_wrappers/wrappers/jannovar/annotate_somatic_vcf/wrapper.py
+++ b/snappy_wrappers/wrappers/jannovar/annotate_somatic_vcf/wrapper.py
@@ -9,7 +9,7 @@ __email__ = "manuel.holtgrewe@bih-charite.de"
 
 # Get shortcuts to static data and step configuration
 static_config = snakemake.config["static_data_config"]
-anno_config = snakemake.config["step_config"]["somatic_variant_annotation"]
+anno_config = snakemake.config["step_config"]["somatic_variant_annotation"]["jannovar"]
 
 # Build list of arguments to pass to Jannovar
 annotation_args = []
@@ -83,7 +83,7 @@ annotation_snippet = " \\\n    ".join(annotation_args)
 # Build intervals argument
 arg_intervals = " ".join(
     ["--interval {}".format(interval) for interval in snakemake.params["args"]["intervals"]]
-)
+) if "args" in snakemake.params and "intervals" in snakemake.params["args"] else ""
 
 shell(
     r"""
@@ -113,8 +113,8 @@ jannovar \
     -XX:+UseG1GC \
     --input-vcf {snakemake.input.vcf} \
     --output-vcf {snakemake.output.vcf} \
-    --database {snakemake.config[step_config][somatic_variant_annotation][path_jannovar_ser]} \
-    --ref-fasta {snakemake.config[static_data_config][reference][path]} \
+    --database {anno_config[path_jannovar_ser]} \
+    --ref-fasta {static_config[reference][path]} \
     {arg_intervals} \
     {annotation_snippet}
 

--- a/snappy_wrappers/wrappers/jannovar/annotate_somatic_vcf/wrapper.py
+++ b/snappy_wrappers/wrappers/jannovar/annotate_somatic_vcf/wrapper.py
@@ -81,9 +81,13 @@ for conf in anno_config["annotation_tracks_vcf"]:
 annotation_snippet = " \\\n    ".join(annotation_args)
 
 # Build intervals argument
-arg_intervals = " ".join(
-    ["--interval {}".format(interval) for interval in snakemake.params["args"]["intervals"]]
-) if "args" in snakemake.params and "intervals" in snakemake.params["args"] else ""
+arg_intervals = (
+    " ".join(
+        ["--interval {}".format(interval) for interval in snakemake.params["args"]["intervals"]]
+    )
+    if "args" in snakemake.params and "intervals" in snakemake.params["args"]
+    else ""
+)
 
 shell(
     r"""

--- a/snappy_wrappers/wrappers/vcf2maf/vcf_to_table/jannovar.yaml
+++ b/snappy_wrappers/wrappers/vcf2maf/vcf_to_table/jannovar.yaml
@@ -348,6 +348,7 @@ output:                                               # Output columns definitio
             add_sequence: False                       # The arguments "add_sequence", "want_short" & "want_long"
             want_short: True                          # allow the user to change this behaviour.
             want_long: False
+            illegal: True                             # Skip variant when HGVSp is illegal
         on_missing: skip
         # default: ""
 

--- a/snappy_wrappers/wrappers/vcf2maf/vcf_to_table/vep.yaml
+++ b/snappy_wrappers/wrappers/vcf2maf/vcf_to_table/vep.yaml
@@ -350,6 +350,7 @@ output:                                               # Output columns definitio
             add_sequence: False                       # The arguments "add_sequence", "want_short" & "want_long"
             want_short: True                          # allow the user to change this behaviour.
             want_long: False
+            illegal: False                            # Allow some illegal HGVSp format, replacing them with empty
         on_missing: skip
         # default: ""
 

--- a/snappy_wrappers/wrappers/vep/post_filter/wrapper.py
+++ b/snappy_wrappers/wrappers/vep/post_filter/wrapper.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+from snakemake import shell
+import vcfpy
+
+inp = snakemake.input.vcf
+out = snakemake.output.vcf
+escape = snakemake.config["step_config"][snakemake.config["pileline_step"]["name"]]["vep"]["escape"]
+
+# Nomenclature taken from ENSEMBL 110 (http://www.ensembl.org/info/genome/variation/prediction/predicted_data.html)
+variant_classes_vep = (
+    "transcript_ablation",
+    "splice_acceptor_variant",
+    "splice_donor_variant",
+    "stop_gained",
+    "frameshift_variant",
+    "stop_lost",
+    "start_lost",
+    "transcript_amplification",
+    "feature_elongation",
+    "feature_truncation",
+    "__end_of_HIGH_IMPACT",
+    "inframe_insertion",
+    "inframe_deletion",
+    "missense_variant",
+    "protein_altering_variant",
+    "__end_of_MODERATE_IMPACT",
+    "splice_donor_5th_base_variant",
+    "splice_region_variant",
+    "splice_donor_region_variant",
+    "splice_polypyrimidine_tract_variant",
+    "incomplete_terminal_codon_variant",
+    "start_retained_variant",
+    "stop_retained_variant",
+    "synonymous_variant",
+    "__end_of_LOW_IMPACT",
+    "coding_sequence_variant",
+    "mature_miRNA_variant",
+    "5_prime_UTR_variant",
+    "3_prime_UTR_variant",
+    "non_coding_transcript_exon_variant",
+    "intron_variant",
+    "NMD_transcript_variant",
+    "non_coding_transcript_variant",
+    "coding_transcript_variant",
+    "upstream_gene_variant",
+    "downstream_gene_variant",
+    "TFBS_ablation",
+    "TFBS_amplification",
+    "TF_binding_site_variant",
+    "regulatory_region_ablation",
+    "regulatory_region_amplification",
+    "regulatory_region_variant",
+    "intergenic_variant",
+    "sequence_variant",
+    "__end_of_MODIFIER_IMPACT",
+    "",
+)
+
+appris_codes = ("P1", "A1", "P2", "A2", "P3", "P4", "P5", "")
+tsl_codes = ("1", "2", "3", "4", "5", "NA", "")
+criteria = ("MANE", "Consequence", "APPRIS", "TSL")
+
+reduced_escape_mapping = [
+    (";", "%3B"),
+    ("\r", "%0D"),
+    ("\n", "%0A"),
+    ("\t", "%09"),
+]
+
+sep = re.compile("\|")
+prefix = re.compile("^Consequence annotations from Ensembl VEP. Format: ")
+ampersand = re.compile("&")
+
+
+def get_value(criterion, x):
+    if criterion == "MANE":
+        return _get_value_MANE(x)
+    if criterion == "Consequence":
+        return _get_value_Consequence(x)
+    if criterion == "APPRIS":
+        return _get_value_APPRIS(x)
+    if criterion == "TSL":
+        return _get_value_TSL(x)
+
+
+def _get_value_MANE(x):
+    if x:
+        return 0
+    else:
+        return 1
+
+
+def _get_value_Consequence(x):
+    consequences = ampersand.split(x)
+    worst = None
+    for consequence in consequences:
+        try:
+            i = variant_classes_vep.index(consequence)
+            if worst is None or i < worst:
+                worst = i
+        except ValueError:
+            print("WARNING- unknown consequence {}".format(consequence))
+    if worst is None:
+        return len(variant_classes_vep) - 1
+    else:
+        return worst
+
+
+def _get_value_APPRIS(x):
+    try:
+        return appris_codes.index(x)
+    except ValueError:
+        print("WARNING- unknown APPRIS code {}".format(x))
+        return len(appris_codes) - 1
+
+
+def _get_value_TSL(x):
+    try:
+        return tsl_codes.index(str(x))
+    except ValueError:
+        print("WARNING- unknown TSL code {}".format(x))
+        return len(tsl_codes) - 1
+
+
+reader = vcfpy.Reader.from_path(inp)
+header = reader.header.copy()
+
+if (
+    not escape
+    and header.lines[0].key == "fileformat"
+    and header.lines[0].value in ("VCFv4.1", "VCFv4.2")
+):
+    vcfpy.record.ESCAPE_MAPPING = reduced_escape_mapping
+
+csq = header.get_info_field_info("CSQ")
+titles = sep.split(prefix.sub("", header.get_info_field_info("CSQ").description))
+csq.mapping["Number"] = 1
+
+writer = vcfpy.Writer.from_path(out, header)
+
+for record in reader:
+    codes = {
+        "MANE": 1,
+        "Consequence": len(variant_classes_vep) - 1,
+        "APPRIS": len(appris_codes) - 1,
+        "TSL": len(tsl_codes) - 1,
+    }
+    chosen = None
+    first = None
+    for oneAnnotation in record.INFO["CSQ"]:
+        fields = sep.split(str(oneAnnotation))
+        assert len(fields) == len(titles)
+        fields = {titles[i]: fields[i] for i in range(len(fields))}
+
+        if not first:
+            first = fields
+
+        selected = False
+        for criterion in criteria:
+            result = get_value(criterion, fields[criterion])
+            if result is None or result == codes[criterion]:
+                continue
+            selected = result < codes[criterion]
+            break
+
+        if selected:
+            for criterion in criteria:
+                codes[criterion] = get_value(criterion, fields[criterion])
+            chosen = fields.values()
+
+    assert first is not None
+    if chosen is None:
+        chosen = first.values()
+
+    record.INFO["CSQ"] = "|".join(chosen)
+
+    writer.write_record(record)
+
+writer.close()
+
+shell(
+    r"""
+tabix {snakemake.output.vcf}
+
+d=$(dirname {snakemake.output.vcf})
+pushd
+f=$(basename {snakemake.output.vcf})
+md5sum $f > $f.md5
+md5sum $f.tbi > $f.tbi.md5
+popd
+"""
+)

--- a/tests/snappy_pipeline/workflows/test_workflows_cbioportal_export.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_cbioportal_export.py
@@ -528,10 +528,7 @@ def test_cbioportal_cna_step_part_get_args_log2(cbioportal_export_workflow):
     """Tests cbioportalCnaFilesStepPart.get_args() -action 'log2'"""
     # Define expected
     base_name_out = "work/log/cbioportal_cna"
-    expected = {
-        "action_type": "log2",
-        "extra_args": {"amplification": "9", "pipeline_id": "ENSEMBL"},
-    }
+    expected = {"action_type": "log2", "extra_args": {"pipeline_id": "ENSEMBL"}}
     # Get actual
     actual = cbioportal_export_workflow.get_args("cbioportal_cna", "log2")
     assert actual == expected
@@ -541,7 +538,10 @@ def test_cbioportal_cna_step_part_get_args_gistic(cbioportal_export_workflow):
     """Tests cbioportalCnaFilesStepPart.get_args() -action 'gistic'"""
     # Define expected
     base_name_out = "work/log/cbioportal_cna"
-    expected = {"action_type": "gistic", "extra_args": {"pipeline_id": "ENSEMBL"}}
+    expected = {
+        "action_type": "gistic",
+        "extra_args": {"amplification": "9", "pipeline_id": "ENSEMBL"},
+    }
     # Get actual
     actual = cbioportal_export_workflow.get_args("cbioportal_cna", "gistic")
     assert actual == expected

--- a/tests/snappy_pipeline/workflows/test_workflows_somatic_variant_annotation.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_somatic_variant_annotation.py
@@ -181,6 +181,8 @@ def test_vep_step_part_get_output_files(somatic_variant_annotation_workflow):
         "{mapper}.{var_caller}.vep.{tumor_library}"
     )
     expected = get_expected_output_vcf_files_dict(base_out=base_out)
+    full = {k.replace("vcf", "full"): v.replace(".vcf", ".full.vcf") for k, v in expected.items()}
+    expected = {**expected, **full}
     actual = somatic_variant_annotation_workflow.get_output_files("vep", "run")
     assert actual == expected
 
@@ -239,6 +241,16 @@ def test_somatic_variant_annotation_workflow(somatic_variant_annotation_workflow
         for mapper in ("bwa",)
         for var_caller in ("mutect", "scalpel")
         for annotator in ("jannovar_annotate_somatic_vcf", "vep")
+    ]
+    expected += [
+        tpl.format(
+            mapper=mapper, var_caller=var_caller, annotator=annotator, i=i, t=t, ext=ext, dir_="out"
+        )
+        for i, t in ((1, 1), (2, 1), (2, 2))
+        for ext in ("full.vcf.gz", "full.vcf.gz.md5", "full.vcf.gz.tbi", "full.vcf.gz.tbi.md5")
+        for mapper in ("bwa",)
+        for var_caller in ("mutect", "scalpel")
+        for annotator in ("vep",)
     ]
     expected += [
         tpl.format(


### PR DESCRIPTION
Impose user-defined annotation order for VEP.
Previously, the wrapper was using the default order, based on ENSEMBL canonical transcript.
Because of that choice, many variant were not uploaded to cBioPortal.

The default choice now prioritizes protein-coding genes with MANE transcripts.
Many variants are now recovered in cBioPortal views.