### PR TITLE
fix: mehari wrapper vcf preprocessing does not actually fix info svlen header (#450)

### DIFF
--- a/snappy_wrappers/wrappers/mehari/annotate_strucvars/wrapper.py
+++ b/snappy_wrappers/wrappers/mehari/annotate_strucvars/wrapper.py
@@ -62,7 +62,7 @@ fi
 
 # Create auto-cleaned temporary directory
 export TMPDIR=$(mktemp -d)
-#trap "rm -rf $TMPDIR" EXIT
+trap "rm -rf $TMPDIR" EXIT
 
 # Run actual tools --------------------------------------------------------------------------------
 


### PR DESCRIPTION
fix: mehari wrapper vcf preprocessing does not actually fix info svlen header (#450)