### PR TITLE
fix: definition of gcnv conda enviroment for mamba>=1.3 (#452)

### DIFF
--- a/snappy_wrappers/wrappers/gcnv/environment.yaml
+++ b/snappy_wrappers/wrappers/gcnv/environment.yaml
@@ -15,13 +15,13 @@ dependencies:
   - conda-forge::mkl-service =2.3.0
   - conda-forge::numpy =1.17.5
   - conda-forge::theano =1.0.4
-  - defaults::tensorflow =1.15.0
+  - tensorflow =1.15.0
   - conda-forge::scipy =1.0.0
   - conda-forge::pymc3 =3.1
   - conda-forge::joblib =1.2.0
   - conda-forge::h5py =2.10.0
   - conda-forge::keras =2.2.4
-  - defaults::intel-openmp =2019.4
+  - intel-openmp =2019.4
   - conda-forge::scikit-learn =0.23.1
   - conda-forge::matplotlib =3.2.1
   - conda-forge::pandas =1.0.3


### PR DESCRIPTION
fix: definition of gcnv conda enviroment for mamba>=1.3 (#452)

Leaving out the 'default::' seems to work, see my comment on the issue