### PR TITLE
feat: Initial implementation of Molecular bar codes handling using AGeNT

### DIFF
--- a/snappy_pipeline/workflows/ngs_data_qc/__init__.py
+++ b/snappy_pipeline/workflows/ngs_data_qc/__init__.py
@@ -105,6 +105,8 @@ class FastQcReportStepPart(BaseStepPart):
     #: Class available actions
     actions = ("run",)
 
+    default_resource_usage = ResourceUsage(threads=1, memory="4G", time="03:59:59")
+
     def __init__(self, parent):
         super().__init__(parent)
         self.base_path_in = "work/input_links/{library_name}"

--- a/snappy_pipeline/workflows/ngs_mapping/Snakefile
+++ b/snappy_pipeline/workflows/ngs_mapping/Snakefile
@@ -118,6 +118,28 @@ rule ngs_mapping_bwa_mem2_run:
         wf.wrapper_path("bwa_mem2")
 
 
+# Run Molecular Barcodes meta-tool --------------------------------------------
+
+
+rule ngs_mapping_mbcs_run:
+    input:
+        wf.get_input_files("mbcs", "run"),
+    output:
+        **wf.get_output_files("mbcs", "run"),
+    threads: wf.get_resource("mbcs", "run", "threads")
+    resources:
+        time=wf.get_resource("mbcs", "run", "time"),
+        memory=wf.get_resource("mbcs", "run", "memory"),
+        partition=wf.get_resource("mbcs", "run", "partition"),
+        tmpdir=wf.get_resource("mbcs", "run", "tmpdir"),
+    params:
+        args=wf.substep_dispatch("mbcs", "get_args", "run"),
+    log:
+        **wf.get_log_file("mbcs", "run"),
+    wrapper:
+        wf.wrapper_path("mbcs")
+
+
 # Run STAR --------------------------------------------------------------------
 
 

--- a/snappy_pipeline/workflows/ngs_mapping/__init__.py
+++ b/snappy_pipeline/workflows/ngs_mapping/__init__.py
@@ -323,7 +323,7 @@ EXT_VALUES = (".bam", ".bam.bai", ".bam.md5", ".bam.bai.md5")
 EXT_NAMES = ("bam", "bai", "bam_md5", "bai_md5")
 
 #: Available read mappers for (short/Illumina) DNA-seq data
-READ_MAPPERS_DNA = ("bwa", "bwa_mem2")
+READ_MAPPERS_DNA = ("bwa", "bwa_mem2", "mbcs")
 
 #: Available read mappers for (short/Illumina) RNA-seq data
 READ_MAPPERS_RNA = ("star",)
@@ -389,6 +389,21 @@ step_config:
       trim_adapters: false
       mask_duplicates: true
       split_as_secondary: true  # -M flag
+    # Configuration for mbcs (meta sub-step to deal with Molecular Barcodes & base uqality recalibration)
+    mbcs:
+      mapping_tool: REQUIRED  # Either bwa of bwa_mem2. The indices & other parameters are taken from mapper config
+      mbc_tool: agent         # Only agent currently implemented
+      agent:
+        prepare:
+          path: REQUIRED
+          lib_prep_type: REQUIRED # One of "halo" (HaloPlex), "hs" (HaloPlexHS), "xt" (SureSelect XT, XT2, XT HS), "v2" (SureSelect XT HS2) & "qxt" (SureSelect QXT)
+          extra_args: []      # Consider "-polyG 8" for NovaSeq data & "-minFractionRead 50" for 100 cycles data
+        mark_duplicates:
+          path: REQUIRED
+          consensus_mode: REQUIRED # One of "SINGLE", "HYBRID", "DUPLEX"
+          input_filter_args: []
+          consensus_filter_args: []
+          extra_args: []
     # Configuration for STAR
     star:
       path_index: REQUIRED # Required if listed in ngs_mapping.tools.rna; otherwise, can be removed.
@@ -758,6 +773,73 @@ class BwaMem2StepPart(ReadMappingStepPart):
                 raise InvalidConfiguration(
                     f"Expected BWA-MEM2 input path {expected_path} does not exist!"
                 )
+
+
+class MBCsStepPart(ReadMappingStepPart):
+    """Support for performing NGS alignment on MBC data"""
+
+    name = "mbcs"
+    tool_category = "dna"
+
+    LIB_PREP_TYPES = ("halo", "hs", "xt", "v2", "qxt")
+    CONSENSUS_MODES = ("SINGLE", "HYBRID", "DUPLEX")
+
+    def get_resource_usage(self, action):
+        """Get Resource Usage
+
+        :param action: Action (i.e., step) in the workflow, example: 'run'.
+        :type action: str
+
+        :return: Returns ResourceUsage for step.
+
+        :raises UnsupportedActionException: if action not in class defined list of valid actions.
+        """
+        self._validate_action(action)
+        return ResourceUsage(
+            threads=1,
+            time="24:00:00",
+            memory="4G",
+        )
+
+    def check_config(self):
+        """Check parameters in configuration.
+
+        Method checks that all parameters required to execute BWA-MEM2 are present in the
+        configuration. It further checks that the provided index has all the expected file
+        extensions. If invalid configuration, it raises InvalidConfiguration exception.
+        """
+        # Check if tool is at all included in workflow
+        if self.__class__.name not in self.config["tools"]["dna"]:
+            return  # mbcs not run, don't check configuration  # pragma: no cover
+
+        # Check mapper
+        mapper = self.config["mbcs"]["mapping_tool"]
+        assert mapper != "mbcs" and mapper in READ_MAPPERS_DNA, f'Unknown mapper "{mapper}"'
+        self.parent.sub_steps[mapper].check_config()
+
+        # Check trimmer & creak paths
+        path = self.config["mbcs"]["agent"]["prepare"]["path"]
+        if not os.path.exists(path):
+            raise InvalidConfiguration(
+                f"Expected agent's trimmer input path {path} does not exist!"
+            )
+        path = self.config["mbcs"]["agent"]["mark_duplicates"]["path"]
+        if not os.path.exists(path):
+            raise InvalidConfiguration(f"Expected agent's creak input path {path} does not exist!")
+
+        # Check mandatory options
+        option = self.config["mbcs"]["agent"]["prepare"]["lib_prep_type"]
+        if option not in self.__class__.LIB_PREP_TYPES:
+            options = '", "'.join(self.__class__.LIB_PREP_TYPES)
+            raise InvalidConfiguration(
+                f'Unkown library preparation type "{option}", valid options are "{options}"'
+            )
+        option = self.config["mbcs"]["agent"]["mark_duplicates"]["consensus_mode"]
+        if option not in self.__class__.CONSENSUS_MODES:
+            options = '", "'.join(self.__class__.CONSENSUS_MODES)
+            raise InvalidConfiguration(
+                f'Unkown consensus mode "{option}", valid options are "{options}"'
+            )
 
 
 class StarStepPart(ReadMappingStepPart):
@@ -1362,6 +1444,7 @@ class NgsMappingWorkflow(BaseStep):
             (
                 BwaStepPart,
                 BwaMem2StepPart,
+                MBCsStepPart,
                 ExternalStepPart,
                 LinkInStep,
                 Minimap2StepPart,

--- a/snappy_wrappers/wrapper_parallel.py
+++ b/snappy_wrappers/wrapper_parallel.py
@@ -220,6 +220,7 @@ class SnakemakeExecutionFailed(Exception):
 def run_snakemake(
     config,
     snakefile="Snakefile",
+    cores=1,
     num_jobs=0,
     max_jobs_per_second=0,
     max_status_checks_per_second=0,
@@ -253,7 +254,7 @@ def run_snakemake(
             snakefile,
             workdir=os.getcwd(),
             jobname="snakejob{token}.{{rulename}}.{{jobid}}.sh".format(token="." + job_name_token),
-            cores=1,
+            cores=cores,
             nodes=num_jobs or config["num_jobs"],
             max_jobs_per_second=max_jobs_per_second or config["max_jobs_per_second"],
             max_status_checks_per_second=max_status_checks_per_second

--- a/snappy_wrappers/wrappers/cbioportal/generate_cna/script.R
+++ b/snappy_wrappers/wrappers/cbioportal/generate_cna/script.R
@@ -16,6 +16,7 @@ cns_to_cna <- function(fn, tx_obj=TxDb.Hsapiens.UCSC.hg19.knownGene::TxDb.Hsapie
     stopifnot(all(c("chrom", "loc.start", "loc.end", "seg.mean", "C") %in% colnames(segments)))
 
     seg <- GenomicRanges::makeGRangesFromDataFrame(segments, seqnames.field="chrom", start.field="loc.start", end.field="loc.end", strand="*", keep.extra.columns=FALSE)
+    GenomeInfoDb::seqlevelsStyle(seg) <- GenomeInfoDb::seqlevelsStyle(genes)
 
     i <- GenomicRanges::findOverlaps(genes, seg)
     i <- split(S4Vectors::subjectHits(i), S4Vectors::queryHits(i))

--- a/snappy_wrappers/wrappers/cbioportal/merge_tables/script.R
+++ b/snappy_wrappers/wrappers/cbioportal/merge_tables/script.R
@@ -99,7 +99,7 @@ merge_segments <- function(fns) {
     if (is.null(names(fns)))
         stop("Missing sample names")
 
-    col_names <- c("chrom", "loc.start", "loc.end", "num.marks", "seg.mean")
+    col_names <- c("chrom", "loc.start", "loc.end", "num.mark", "seg.mean")
     tbl <- NULL
     for (sample_id in names(fns)) {
         cat("Loading", fns[sample_id], "for sample", sample_id, "\n")
@@ -110,7 +110,7 @@ merge_segments <- function(fns) {
         tbl <- rbind(tbl, tmp)
     }
 
-    return(tbl)
+    return(tbl[,c("ID", col_names)])
 }
 
 #' Aggregates counts and computes RPKM

--- a/snappy_wrappers/wrappers/cnvkit/postprocess/wrapper.py
+++ b/snappy_wrappers/wrappers/cnvkit/postprocess/wrapper.py
@@ -67,7 +67,7 @@ segments[,"end"]   <- segments[["end"]]+1
 segments[,"ID"] <- "{snakemake.wildcards[library_name]}"
 
 # Rename columns to follow DNAcopy format (as implemented in PureCN)
-dna_copy_columns <- c(ID="ID", chromosome="chrom", start="loc.start", end="loc.end", probes="num.marks", log2="seg.mean", cn="C")
+dna_copy_columns <- c(ID="ID", chromosome="chrom", start="loc.start", end="loc.end", probes="num.mark", log2="seg.mean", cn="C")
 segments <- segments[,colnames(segments) %in% names(dna_copy_columns)]
 colnames(segments) <- dna_copy_columns[colnames(segments)]
 segments <- segments[,dna_copy_columns]

--- a/snappy_wrappers/wrappers/mbcs/environment.yaml
+++ b/snappy_wrappers/wrappers/mbcs/environment.yaml
@@ -1,0 +1,13 @@
+channels:
+- conda-forge
+- bioconda
+dependencies:
+- cffi
+- pandas
+- numpy
+- snakemake-minimal
+- openjdk =17
+- seqtk
+- samtools
+- bwa-mem2 ==2.2.1
+- gatk4

--- a/snappy_wrappers/wrappers/mbcs/environment.yaml
+++ b/snappy_wrappers/wrappers/mbcs/environment.yaml
@@ -11,3 +11,5 @@ dependencies:
 - samtools
 - bwa-mem2 ==2.2.1
 - gatk4
+- trimadap
+- samblaster

--- a/snappy_wrappers/wrappers/mbcs/wrapper.py
+++ b/snappy_wrappers/wrappers/mbcs/wrapper.py
@@ -1,0 +1,357 @@
+# -*- coding: utf-8 -*-
+"""CUBI+Snakemake wrapper code for MTB-aware exome data
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+from snakemake import shell
+
+# The following is required for being able to import snappy_wrappers modules
+# inside wrappers.  These run in an "inner" snakemake process which uses its
+# own conda environment which cannot see the snappy_pipeline installation.
+base_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+sys.path.insert(0, base_dir)
+
+from snappy_wrappers.wrapper_parallel import run_snakemake
+
+__author__ = "Eric Blanc <eric.blanc@bih-charite.de>"
+
+shell.executable("/bin/bash")
+
+# Rules templates =============================================================
+
+# Main rule: rule all ---------------------------------------------------------
+head_rule = r"""
+shell.prefix("set -xeuo pipefail; ")
+
+rule all:
+    input:
+        "{output_bam}"
+"""
+
+# Trim UMIs & map one pair of fastq files -------------------------------------
+paired_rule = r"""
+rule trim_{iPair}:
+    input:
+        r1 = "{r1}",
+        r2 = "{r2}"
+    output:
+        r1 = "trimmed/{name}_R1.fastq.gz",
+        r2 = "trimmed/{name}_R2.fastq.gz"
+    log:
+        "log/{name}_trim.log"
+    resources:
+        mem_mb = "64000M",
+        time = "24:00:00"
+    shell:
+        r'''
+            java -Xmx60G -jar {trimmer} \
+                -{lib_prep_type} {extra_args} \
+                -out "trimmed/{name}" \
+                -fq1 {{input.r1}} -fq2 {{input.r2}}
+        '''
+
+rule map_{iPair}:
+    input:
+        r1 = "trimmed/{name}_R1.fastq.gz",
+        r2 = "trimmed/{name}_R2.fastq.gz"
+    output:
+        bam = "mapped/{name}.bam"
+    log:
+        "log/{name}_map.log"
+    resources:
+        mem_mb = "64000M",
+        time = "24:00:00"
+    threads: 16
+    params:
+        indices = "{indices}"
+    shell:
+        r'''
+            seqtk mergepe <(zcat {{input.r1}}) <(zcat {{input.r2}}) \
+                | {mapper} mem {{params.indices}} -t {{threads}} -p -R '@RG\tID:{name}\tSM:{sample}\tPL:ILLUMINA' -C /dev/stdin \
+                | samtools sort -O BAM -o {{output.bam}}
+            samtools index {{output.bam}}
+        '''
+"""
+
+# Trim & map one fastq file (unpaired) ----------------------------------------
+unpaired_rule = r"""
+rule trim_{iPair}:
+    input:
+        r1 = "{r1}"
+    output:
+        r1 = "trimmed/{name}_R1.fastq.gz"
+    log:
+        "log/{name}_trim.log"
+    resources:
+        mem_mb = "64000M",
+        time = "24:00:00"
+    shell:
+        r'''
+            java -Xmx60G -jar {trimmer} -fq1 {{input.r1}}
+        '''
+
+rule map_{iPair}:
+    input:
+        r1 = "trimmed/{name}_R1.fastq.gz"
+    output:
+        bam = "mapped/{name}.bam"
+    log:
+        "log/{name}_map.log"
+    resources:
+        mem_mb = "64000M",
+        time = "24:00:00"
+    threads: {threads}
+    params:
+        indices = "{indices}"
+    shell:
+        r'''
+            seqtk mergepe <(zcat {{input.r1}}) \
+                | {mapper} mem {{params.indices}} -t {{threads}} -p -R '@RG\tID:{name}\tSM:{sample}\tPL:ILLUMINA' -C /dev/stdin \
+                | samtools sort -O BAM -o {{output.bam}}
+            samtools index {{output.bam}}
+        '''
+"""
+
+# Merge, mark duplicated and base quality recalibration on all data -----------
+merge_rule = r"""
+rule merge:
+    input:
+        pairs = [{pairs}]
+    output:
+        bam = "merged.bam"
+    log:
+        "log/merge.log"
+    shell:
+        r'''
+            samtools merge -O BAM -o {{output.bam}} -f -s 1234567 {{input.pairs}}
+            samtools index {{output.bam}}
+        '''
+
+rule mark:
+    input:
+        bam = "merged.bam"
+    output:
+        bam = "marked.bam"
+    log:
+        "log/marked.log"
+    resources:
+        mem_mb = "64000M",
+        time = "24:00:00"
+    shell:
+        r'''
+            java -Xmx60G -jar {marker} \
+                {extra_args} -c={consensus_mode} \
+                -o={{output.bam}} \
+                -f {input_filer_args} -F {consensus_filter_args} \
+                {{input.bam}}
+
+            samtools index {{output.bam}}
+        '''
+    
+rule bqsr:
+    input:
+        bam = "marked.bam"
+    output:
+        tbl = "bqsr.tbl"
+    log:
+        "log/bqsr.log"
+    params:
+        reference = "{reference}",
+        common_sites = "{common_sites}"
+    shell:
+        r'''
+            gatk BaseRecalibrator \
+                -I {{input.bam}} \
+                -R {{params.reference}} --known-sites {{params.common_sites}} \
+                -O {{output.tbl}}
+        '''
+
+rule apply:
+    input:
+        bam = "marked.bam",
+        tbl = "bqsr.tbl"
+    output:
+        bam = "{output_bam}"
+    log:
+        "log/apply.log"
+    params:
+        reference = "{reference}"
+    shell:
+        r'''
+            gatk ApplyBQSR \
+                -I {{input.bam}} --bqsr-recal-file {{input.tbl}} \
+                -R {{params.reference}} \
+                -O {{output.bam}}
+
+            samtools index {{output.bam}}
+        '''
+"""
+
+# Main script =================================================================
+
+# Input fastqs are passed through snakemake.params.
+# snakemake.input is a .done file touched after linking files in.
+input_left = snakemake.params.args["input"]["reads_left"]
+input_right = snakemake.params.args["input"].get("reads_right", "")
+
+config = snakemake.config["step_config"]["ngs_mapping"]["mbcs"]
+
+# Group mate pairs
+r1s = input_left.copy()
+
+pairs = {}
+for r2 in input_right:
+    f = os.path.basename(r2).replace("_R2", "_R1")
+    r1 = None
+    for x in r1s:
+        if os.path.basename(x) == f:
+            r1 = x
+            break
+    assert r1 is not None
+    name = f[: f.index("_R1")]
+    assert name not in pairs.keys()
+    pairs[name] = (os.path.abspath(r1), os.path.abspath(r2))
+    r1s.remove(r1)
+
+for r1 in r1s:
+    f = os.path.basename(r1)
+    assert "_R1" in f
+    name = f[: f.index("_R1")]
+    assert name not in pairs.keys()
+    pairs[name] = (os.path.abspath(r1),)
+
+# Create Snakefile
+snakefile = []
+
+rule = head_rule.format(output_bam=os.path.abspath(snakemake.output.bam))
+snakefile.append(rule)
+
+mapper = config["mapping_tool"]
+tool = config["mbc_tool"]
+for iPair, name in enumerate(pairs.keys()):
+    kwargs = {
+        "iPair": iPair,
+        "name": name,
+        "r1": pairs[name][0],
+        "r2": pairs[name][1],
+        "trimmer": config[tool]["prepare"]["path"],
+        "lib_prep_type": config[tool]["prepare"]["lib_prep_type"],
+        "extra_args": " ".join(config[tool]["prepare"]["extra_args"]),
+        "mapper": mapper if mapper != "bwa_mem2" else "bwa-mem2",
+        "indices": snakemake.config["step_config"]["ngs_mapping"][mapper]["path_index"],
+        "sample": snakemake.params.args["sample_name"],
+        "threads": snakemake.config["step_config"]["ngs_mapping"][mapper]["num_threads_align"],
+    }
+    if len(pairs[name]) == 2:
+        rule = paired_rule.format(**kwargs)
+    else:
+        rule = unpaired_rule.format(**kwargs)
+    snakefile.append(rule)
+
+rule = merge_rule.format(
+    pairs='"' + '", "'.join(["mapped/{}.bam".format(name) for name in pairs.keys()]) + '"',
+    marker=config[tool]["mark_duplicates"]["path"],
+    consensus_mode=config[tool]["mark_duplicates"]["consensus_mode"],
+    input_filer_args=" ".join(config[tool]["mark_duplicates"]["input_filter_args"]),
+    consensus_filter_args=" ".join(config[tool]["mark_duplicates"]["consensus_filter_args"]),
+    extra_args=" ".join(config[tool]["mark_duplicates"]["extra_args"]),
+    reference=snakemake.config["static_data_config"]["reference"]["path"],
+    common_sites=snakemake.config["step_config"]["ngs_mapping"]["mbcs"]["agent"]["common_variants"],
+    output_bam=os.path.abspath(snakemake.output.bam),
+)
+snakefile.append(rule)
+
+snakefile = "\n\n# =======================================================\n\n".join(snakefile)
+
+# Create temp directory, go there, write Snakefile and run
+pwd = os.getcwd()
+
+# import pdb; pdb.set_trace()
+
+tempdir = tempfile.mkdtemp()
+os.chdir(tempdir)
+
+# os.mkdir(os.path.join(tempdir, "slurm_log"), mode=0o750)
+with open("Snakefile", "wt") as f:
+    f.write(snakefile)
+
+slurm_config = {
+    "num_jobs": 10,
+    "max_jobs_per_second": 10,
+    "max_status_checks_per_second": 1,
+    "job_name_token": "ngs_mapping_mbcs",
+    "profile": os.getenv("SNAPPY_PIPELINE_SNAKEMAKE_PROFILE"),
+}
+config["use_profile"] = True
+config["restart_times"] = 1
+run_snakemake(
+    config,
+    **slurm_config,
+)
+
+os.chdir(pwd)
+
+# Finish: write stats, logs & links
+shell(
+    r"""
+set -x
+
+# Write out information about conda and save a copy of the wrapper with picked variables
+# as well as the environment.yaml file.
+conda list >{snakemake.log.conda_list}
+conda info >{snakemake.log.conda_info}
+md5sum {snakemake.log.conda_list} >{snakemake.log.conda_list_md5}
+md5sum {snakemake.log.conda_info} >{snakemake.log.conda_info_md5}
+cp {__real_file__} {snakemake.log.wrapper}
+md5sum {snakemake.log.wrapper} >{snakemake.log.wrapper_md5}
+cp $(dirname {__file__})/environment.yaml {snakemake.log.env_yaml}
+md5sum {snakemake.log.env_yaml} >{snakemake.log.env_yaml_md5}
+
+# Concatenate all log files into main log
+for fn in $(ls -tr {tempdir}/slurm_log/*/*.log)
+do
+    f=$(basename $fn)
+    echo "# ==============================================================" >> {snakemake.log.log}
+    echo "# Log from \"$f\"" >> {snakemake.log.log}
+    echo "# ==============================================================" >> {snakemake.log.log}
+    cat $fn >> {snakemake.log.log}
+done
+md5sum {snakemake.log.log} > {snakemake.log.log_md5}
+
+# Copy BQSR table just in case (not on output)
+mv {tempdir}/bqsr.tbl $(dirname {snakemake.output.bam})
+
+# Build MD5 files
+pushd $(dirname {snakemake.output.bam})
+md5sum $(basename {snakemake.output.bam}) > $(basename {snakemake.output.bam}).md5
+md5sum $(basename {snakemake.output.bam_bai}) > $(basename {snakemake.output.bam_bai}).md5
+popd
+
+# QC Report ---------------------------------------------------------------------------------------
+
+# gather statistics from BAM file
+# TODO: use pipes for only reading once from disk?
+samtools stats    {snakemake.output.bam} > {snakemake.output.report_bamstats_txt}
+samtools flagstat {snakemake.output.bam} > {snakemake.output.report_flagstats_txt}
+samtools idxstats {snakemake.output.bam} > {snakemake.output.report_idxstats_txt}
+
+# Build MD5 files for the reports
+md5sum {snakemake.output.report_bamstats_txt} > {snakemake.output.report_bamstats_txt_md5}
+md5sum {snakemake.output.report_flagstats_txt} >{snakemake.output.report_flagstats_txt_md5}
+md5sum {snakemake.output.report_idxstats_txt} > {snakemake.output.report_idxstats_txt_md5}
+
+# Create output links -----------------------------------------------------------------------------
+
+for path in {snakemake.output.output_links}; do
+  dst=$path
+  src=work/${{dst#output/}}
+  ln -sr $src $dst
+done
+"""
+)
+
+shutil.rmtree(tempdir)

--- a/snappy_wrappers/wrappers/mutect2_par/prepare_panel/parallel_prepare_panel.py
+++ b/snappy_wrappers/wrappers/mutect2_par/prepare_panel/parallel_prepare_panel.py
@@ -33,7 +33,7 @@ class ParallelMutect2Wrapper(ParallelMutect2BaseWrapper):
         self.job_resources = ResourceUsage(
             threads=1,
             memory=gib_to_string(14.0 * self.get_job_mult_memory()),
-            time=hours(4 * self.get_job_mult_time()),
+            time=hours(24 * self.get_job_mult_time()),
             partition=os.getenv("SNAPPY_PIPELINE_PARTITION"),
         )
         self.merge_resources = ResourceUsage(

--- a/snappy_wrappers/wrappers/picard/prepare/wrapper.py
+++ b/snappy_wrappers/wrappers/picard/prepare/wrapper.py
@@ -29,7 +29,7 @@ d=$(ls $CONDA_PREFIX/share | grep picard)
 picard_jar="$CONDA_PREFIX/share/$d/picard.jar"
 if [[ ! -r $picard_jar ]]
 then
-    echo "Can't find picar jar"
+    echo "Can't find picard jar"
     exit -1
 fi
 
@@ -58,7 +58,14 @@ trap "rm -rf $tmpdir" EXIT
 bed_to_interval_list() {{
     fn=$1
     f=$(basename $fn)
-    cut -f 1-3 $fn \
+    if [[ $(od -x -N 2 $fn | head -n 1 | sed -e "s/.* //") = "8b1f" ]]
+    then
+        extract=zcat
+    else
+        extract=cat
+    fi
+    $extract $fn \
+        | cut -f 1-3 \
         | bedtools sort -i - \
         | bedtools merge -i - \
         > $tmpdir/$f

--- a/tests/snappy_pipeline/workflows/test_workflows_ngs_data_qc_processed_fastq.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_ngs_data_qc_processed_fastq.py
@@ -120,7 +120,7 @@ def test_fastqc_step_part_get_log_file(ngs_data_qc):
 def test_fastqc_step_part_get_resource_usage(ngs_data_qc):
     """Tests FastQcReportStepPart.get_resource_usage()"""
     # Define expected: default defined in workflow.abstract
-    expected_dict = {"threads": 1, "time": "01:00:00", "memory": "2G", "partition": "medium"}
+    expected_dict = {"threads": 1, "time": "03:59:59", "memory": "4G", "partition": "medium"}
     # Evaluate
     for resource, expected in expected_dict.items():
         msg_error = f"Assertion error for resource '{resource}'."

--- a/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping.py
@@ -46,13 +46,15 @@ def minimal_config():
               path_index: /path/to/bwa_mem2/index.fasta
             mbcs:
               mapping_tool: bwa
-              agent:
-                prepare:
-                  path: /path/to/trimmer
-                  lib_prep_type: v2
-                mark_duplicates:
-                  path: /path/to/creak
-                  consensus_mode: HYBRID
+            bsqr:
+              common_variants: /path/to/common/variants
+            agent:
+              prepare:
+                path: /path/to/trimmer
+                lib_prep_type: v2
+              mark_duplicates:
+                path: /path/to/creak
+                consensus_mode: HYBRID
             bam_collect_doc:
               enabled: true
 
@@ -331,7 +333,7 @@ def test_bwa_step_part_get_resource(ngs_mapping_workflow):
             "memory": "73728M",
             "partition": "medium",
         },
-        "mbcs": {"threads": 1, "time": "24:00:00", "memory": "4G", "partition": "medium"},
+        "mbcs": {"threads": 1, "time": "72:00:00", "memory": "4G", "partition": "medium"},
     }
     # Evaluate
     for tool, v in expected_dict.items():

--- a/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping_processed_fastq.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_ngs_mapping_processed_fastq.py
@@ -651,6 +651,7 @@ def test_ngs_mapping_workflow_steps(ngs_mapping_workflow):
         "bwa_mem2",
         "external",
         "link_in",
+        "mbcs",
         "minimap2",
         "ngs_chew",
         "star",

--- a/tests/snappy_wrappers/wrappers/data/mutect2_par_prepare_panel.snakemake
+++ b/tests/snappy_wrappers/wrappers/data/mutect2_par_prepare_panel.snakemake
@@ -97,7 +97,7 @@ def resource_chunk_memory(wildcards, attempt):
 
 def resource_chunk_time(wildcards, attempt):
     '''Return the time to use for running one chunk.'''
-    return multiply_time('12:00:00', attempt)
+    return multiply_time('3-00:00:00', attempt)
 
 
 rule all:

--- a/tests/snappy_wrappers/wrappers/test_mutect2_par_prepare_panel.py
+++ b/tests/snappy_wrappers/wrappers/test_mutect2_par_prepare_panel.py
@@ -284,11 +284,11 @@ def test_mutect2_wrapper_prepare_panel_preamble_resource_chunk_time(construct_pr
     """
     # Define (input, expected) pair
     input_expected_pairs = (
-        (1, "0-12:00:00"),
-        (2, "1-00:00:00"),
-        (3, "1-12:00:00"),
-        (4, "2-00:00:00"),
-        (5, "2-12:00:00"),
+        (1, "3-00:00:00"),
+        (2, "6-00:00:00"),
+        (3, "9-00:00:00"),
+        (4, "12-00:00:00"),
+        (5, "15-00:00:00"),
     )
     # Test all pairs
     for pair in input_expected_pairs:


### PR DESCRIPTION
## Prototype implementation of mapping data generated with Molecular BarCodes (MBC) or UMIs.

### Background

The MBCs are typically used on FFPE data, where library complexity may be low. These data are also often compromised by FFPE or oxo-G artifacts which require careful analysis & filtration of somatic variants. Base-quality re-calibration (BQSR) should be used in these cases.

### Design

The implementation has 5 steps:

1. Trimming the MBC sequence at the read's 5' end and inserting it in the read name for further processing.
2. Mapping the reads
3. Merging separate libraries
4. Marking the duplicates using the information in read names
5. Performing BQSR

Steps 1 & 2 must be done separately on separate libraries, in order to easily insert read groups information requires by BQSR. The separate bam files must be merged before marking duplicates.

### Implementation

Because of the multiple operations required to produce the final result, I opted to create a _meta sub-step_, which creates a Snakefile which handles all necessary steps. This is similar to the parallel wrapper, except that the steps are not chunks of the same operation on smaller regions, but logically different operations.

**Benefits**

1. The wrapper creating and running the Snakefile creates a temporary directory where all the disk-intensive operations occur. This avoid cluttering the `work/<tool>.<library>` with large files which are not final results.
2. The code is relatively straightforward, and blends well the the other features from the step (coverage analysis, ...)
3. There is natural parallelisation of libraries sequenced on multiple lanes.

**Drawbacks**

1. The code (as it is now) is inflexible: it is hard to see how another MBC tool could be added, and the mapper must be either `bwa` or `bwa-mem2` (as they share the same input parameters). It is also currently not possible to opt out of BQSR.
2. The notion of _meta sub-step_ may go against the whole `snappy` design.
3. The MBC tool `AGeNT` is a commercial software from Agilent. I don't think it is available on Bioconda. Because of time pressure, I don't have the time to look for alternatives (such as `umitools`).

### Notes

The current implementation must be viewed as a prototype. If the _meta sub-step_ concept is deemed acceptable for `snappy`, I have considered a few options to improve on the current implementation and make it more flexible.

1. The BQSR can easily be put under user control.
2. The mapper wrappers could be modified to adapt their parameters to enable compatibility with the MBC tool (`AGeNT` requires the `-C` option (`append FASTA/FASTQ comment to SAM output`) to be set, add read groups, run on separate libraries).
3. The current wrapper could be abstract, with mbc-tool sprecific concrete classes.

However, in my opinion, all changes and _improvements_ must be weighted against an undue complexification of the `ngs_mapping` step.