### PR TITLE
fix: gcnv contig wrapper scripts do not clean their output folders (#443)

### DIFF
--- a/snappy_wrappers/wrappers/gcnv/call_cnvs_case_mode/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/call_cnvs_case_mode/wrapper.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 from snakemake.shell import shell
 
+#TODO: If the output folder `$(dirname {snakemake.output.done})` exists and was created by another
+# user this will fail. Running rm -rf `$(dirname {snakemake.output.done})` before gatk should fix
+# this issue and once this wrapper is running all previous output files become invalid anyway
+
 paths_tsv = " ".join(snakemake.input.tsv)
 shell(
     r"""

--- a/snappy_wrappers/wrappers/gcnv/contig_ploidy_case_mode/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/contig_ploidy_case_mode/wrapper.py
@@ -1,5 +1,4 @@
 import pathlib
-import shutil
 import sys
 
 from snakemake.shell import shell

--- a/snappy_wrappers/wrappers/gcnv/contig_ploidy_case_mode/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/contig_ploidy_case_mode/wrapper.py
@@ -1,4 +1,5 @@
 import pathlib
+import shutil
 
 from snakemake.shell import shell
 
@@ -54,8 +55,10 @@ for n, sample_dir in enumerate(ploidy_calls.glob("SAMPLE_*")):
         sample_name = inputf.read().strip()
     if n >= n_expected_results and sample_name not in sex_map:
         with open(snakemake.log.log, "a") as log:
-            log.write((f"Skipping {sample_name} as it is not in the PED file"
-                       "and exceeds the number of expected samples.\n"))
+            log.write(
+                f"Encountered a sample most likely leftover from previous snappy run {sample_name} (undefined in samplehseet and above number of expected samples). Purging to ensure later GCNV commands do not load this."
+            )
+        shutil.rmtree(ploidy_calls / sample_dir)
         continue
     sample_sex = sex_map[sample_name]
     path_call = sample_dir / "contig_ploidy.tsv"

--- a/snappy_wrappers/wrappers/gcnv/contig_ploidy_case_mode/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/contig_ploidy_case_mode/wrapper.py
@@ -47,10 +47,16 @@ gatk DetermineGermlineContigPloidy \
 )
 
 ploidy_calls = out_path / "ploidy-calls"
-for sample_dir in ploidy_calls.glob("SAMPLE_*"):
+n_expected_results = len(snakemake.input.tsv)
+for n, sample_dir in enumerate(ploidy_calls.glob("SAMPLE_*")):
     path_name = sample_dir / "sample_name.txt"
     with path_name.open("rt") as inputf:
         sample_name = inputf.read().strip()
+    if n >= n_expected_results and sample_name not in sex_map:
+        with open(snakemake.log.log, "a") as log:
+            log.write((f"Skipping {sample_name} as it is not in the PED file"
+                       "and exceeds the number of expected samples.\n"))
+        continue
     sample_sex = sex_map[sample_name]
     path_call = sample_dir / "contig_ploidy.tsv"
     with path_call.open("rt") as inputf:


### PR DESCRIPTION
Some of the gcnv step_parts and their associated wrappers create collections of output folders that are currently not tracked by snakemake. Additionally gcnv does only partially overwrite these output files & folders, especially if it is run with fewer samples than in a previous run.

This changes the case_mode wrappers for contig_ploidy and call_cnvs step-parts to always remove the directories they will write into to ensure all output files belong to the current snappy run.

This could be extended to the cohort_mode wrappers, however they might be used in cases where removal of previous samples is not intended, since they could still be relevant (whereas in case mode this is not the case).

Fixes #443 
