### PR TITLE
refactor: Schema validation for config files

### DIFF
--- a/snappy_pipeline/base.py
+++ b/snappy_pipeline/base.py
@@ -2,14 +2,16 @@
 """Basic utility code for snappy_pipeline
 """
 
-from collections import OrderedDict
-from collections.abc import MutableMapping
-from copy import deepcopy
 import os
 import sys
 import warnings
+from collections import OrderedDict
+from collections.abc import MutableMapping
+from copy import deepcopy
+from typing import Any
 
 import ruamel.yaml as ruamel_yaml
+from snakemake.utils import validate
 
 # TODO: This has to go away once biomedsheets is a proper, halfway-stable module
 try:
@@ -66,6 +68,13 @@ def expand_ref(config_path, dict_data, lookup_paths=None, dict_class=OrderedDict
             if dirname not in lookup_paths:
                 lookup_paths.append(dirname)
     return resolved, tuple(lookup_paths), tuple(config_files)
+
+
+def validate_config(config: dict[Any, Any], workflow: str, file=sys.stderr):
+    print(f"\nValidating config.yaml for {workflow}", file=file)
+    config_schema_path = os.path.join(os.path.dirname(snakefile_path(workflow)),
+                                      "config.schema.yaml")
+    validate(config, config_schema_path)
 
 
 def print_config(config, file=sys.stderr):

--- a/snappy_pipeline/base.py
+++ b/snappy_pipeline/base.py
@@ -70,12 +70,9 @@ def expand_ref(config_path, dict_data, lookup_paths=None, dict_class=OrderedDict
     return resolved, tuple(lookup_paths), tuple(config_files)
 
 
-def validate_config(config: dict[Any, Any], workflow: str, file=sys.stderr):
-    print(f"\nValidating config.yaml for {workflow}", file=file)
-    config_schema_path = os.path.join(
-        os.path.dirname(snakefile_path(workflow)), "config.schema.yaml"
-    )
-    validate(config, config_schema_path)
+def validate_config(config: dict[Any, Any], schema_path: str, file=sys.stderr):
+    print(f"\nValidating config.yaml using {schema_path}", file=file)
+    validate(config, schema_path)
 
 
 def print_config(config, file=sys.stderr):

--- a/snappy_pipeline/base.py
+++ b/snappy_pipeline/base.py
@@ -2,13 +2,13 @@
 """Basic utility code for snappy_pipeline
 """
 
-import os
-import sys
-import warnings
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from copy import deepcopy
+import os
+import sys
 from typing import Any
+import warnings
 
 import ruamel.yaml as ruamel_yaml
 from snakemake.utils import validate
@@ -72,8 +72,9 @@ def expand_ref(config_path, dict_data, lookup_paths=None, dict_class=OrderedDict
 
 def validate_config(config: dict[Any, Any], workflow: str, file=sys.stderr):
     print(f"\nValidating config.yaml for {workflow}", file=file)
-    config_schema_path = os.path.join(os.path.dirname(snakefile_path(workflow)),
-                                      "config.schema.yaml")
+    config_schema_path = os.path.join(
+        os.path.dirname(snakefile_path(workflow)), "config.schema.yaml"
+    )
     validate(config, config_schema_path)
 
 

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -437,7 +437,8 @@ class AdapterTrimmingStepPart(BaseStepPart):
         super().__init__(parent)
         self.base_path_in = "work/input_links/{library_name}"
         self.base_path_out = "work/{trimmer}.{{library_name}}"
-        validate_config({"adapter_trimming": self.config}, "adapter_trimming")
+        schema_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "config.schema.yaml"))
+        validate_config({"adapter_trimming": self.config}, schema_path)
         #: Path generator for linking in
         self.path_gen = LinkInPathGenerator(
             self.parent.work_dir,

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -142,8 +142,8 @@ import os
 from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import expand
 
-from snappy_pipeline.utils import dictify, listify
 from snappy_pipeline.base import validate_config
+from snappy_pipeline.utils import dictify, listify
 from snappy_pipeline.workflows.abstract import (
     BaseStep,
     BaseStepPart,

--- a/snappy_pipeline/workflows/adapter_trimming/__init__.py
+++ b/snappy_pipeline/workflows/adapter_trimming/__init__.py
@@ -143,6 +143,7 @@ from biomedsheets.shortcuts import GenericSampleSheet
 from snakemake.io import expand
 
 from snappy_pipeline.utils import dictify, listify
+from snappy_pipeline.base import validate_config
 from snappy_pipeline.workflows.abstract import (
     BaseStep,
     BaseStepPart,
@@ -436,6 +437,7 @@ class AdapterTrimmingStepPart(BaseStepPart):
         super().__init__(parent)
         self.base_path_in = "work/input_links/{library_name}"
         self.base_path_out = "work/{trimmer}.{{library_name}}"
+        validate_config({"adapter_trimming": self.config}, "adapter_trimming")
         #: Path generator for linking in
         self.path_gen = LinkInPathGenerator(
             self.parent.work_dir,

--- a/snappy_pipeline/workflows/adapter_trimming/config.schema.yaml
+++ b/snappy_pipeline/workflows/adapter_trimming/config.schema.yaml
@@ -2,18 +2,16 @@ $schema: "https://json-schema.org/draft/2020-12/schema"
 
 description: configuration file for adapter_trimming step
 
+type: object
+
 definitions:
   tfbool:
     type: string
-    enum: ["t", "f"]
+    enum: [ "t", "f" ]
 
-type: object
 properties:
   adapter_trimming:
     type: object
-    required:
-      - tools
-    additionalProperties: false
 
     properties:
       path_link_in:
@@ -44,9 +42,9 @@ properties:
           interleaved:
             description: "(int) t/f overrides interleaved autodetection."
             oneOf:
-              - $ref: #/definitions/tfbool
+              - $ref: "#/definitions/tfbool"
               - type: string
-                enum: [ "auto"]
+                enum: [ "auto" ]
             default: "auto"
           qin:
             description: "Input quality offset: 33 (Sanger), 64, or auto."
@@ -58,11 +56,11 @@ properties:
               (cu) Process non-AGCT IUPAC reference bases by making all
               possible unambiguous copies.  Intended for short motifs
               or adapter barcodes, as time/memory use is exponential.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           nzo:
             description: "Only write statistics about ref sequences with nonzero hits."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: t
           qout:
             description: "Output quality offset: 33 (Sanger), 64, or auto."
@@ -76,19 +74,19 @@ properties:
             default: 3
           rename:
             description: "Rename reads to indicate which sequences they matched."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           refnames:
             description: "Use names of reference files rather than scaffold IDs."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           trd:
             description: "Truncate read and ref names at the first whitespace."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           ordered:
             description: "Set to true to output reads in same order as input."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
 
           # Histogram output parameters:
@@ -113,7 +111,7 @@ properties:
           # Histograms for mapped sam/bam files only:
           histbefore:
             description: "Calculate histograms from reads before processing."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: t
           idbins:
             description: "Number idhist bins.  Set to 'auto' to use read length."
@@ -133,7 +131,7 @@ properties:
             default: 21
           rcomp:
             description: "Look for reverse-complements of kmers in addition to forward kmers."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: t
 
           # Processing parameters:
@@ -141,7 +139,7 @@ properties:
             description: >
               (mm) Treat the middle base of a kmer as a wildcard, to
               increase sensitivity in the presence of errors.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: t
           minkmerhits:
             description: >
@@ -197,40 +195,40 @@ properties:
               (fn) Forbids matching of read kmers containing N.
               By default, these will match a reference 'A' if
               hdist>0 or edist>0, to increase sensitivity.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           removeifeitherbad:
             description: >
               (rieb) Paired reads get sent to 'outmatch' if either is
               match (or either is trimmed shorter than minlen).
               Set to false to require both.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: t
           trimfailures:
             description: >
               Instead of discarding failed reads, trim them to 1bp.
               This makes the statistics a bit odd.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           findbestmatch:
             description: >
               (fbm) If multiple matches, associate read with sequence
               sharing most kmers.  Reduces speed.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           skipr1:
             description: "Don't do kmer-based operations on read 1."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           skipr2:
             description: "Don't do kmer-based operations on read 2."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           ecco:
             description: >
               For overlapping paired reads only.  Performs error-
               correction with BBMerge prior to kmer operations.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           # Trimming/Filtering/Masking parameters:
           # Note - if ktrim, kmask, and ksplit are unset, the default behavior is kfilter.
@@ -256,7 +254,7 @@ properties:
             default: ""
           maskfullycovered:
             description: "(mfc) Only mask bases that are fully covered by kmers."
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           ksplit:
             description: >
@@ -265,7 +263,7 @@ properties:
               read, it will be trimmed instead.  Singletons will go to
               out, and pairs will go to outm.  Do not use ksplit with
               other operations such as quality-trimming or filtering.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           mink:
             description: >
@@ -339,7 +337,7 @@ properties:
             description: >
               (outputtrimmedtomatch) Output reads trimmed to shorter
               than minlength to outm rather than discarding.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           tp:
             description: >
@@ -349,12 +347,12 @@ properties:
           tbo:
             description: >
               (trimbyoverlap) Trim adapters based on where paired reads overlap.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           strictoverlap:
             description: >
               Adjust sensitivity for trimbyoverlap mode.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: t
           minoverlap:
             description: >
@@ -371,7 +369,7 @@ properties:
             description: >
               (trimpairsevenly) When kmer right-trimming, trim both
               reads to the minimum length of either.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           forcetrimleft:
             description: >
@@ -422,24 +420,24 @@ properties:
             description: >
               Use average GC of paired reads.    Deprecated option?
               Also affects gchist.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: t
           tossjunk:
             description: >
               Discard reads with invalid characters as bases.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           swift:
             description: >
               Trim Swift sequences: Trailing C/T/N R1, leading G/A/N R2.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
 
           # Header-parsing parameters - these require Illumina headers:
           chastityfilter:
             description: >
               (cf) Discard reads with id containing ' 1:Y:' or ' 2:Y:'.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           barcodefilter:
             description: |
@@ -559,18 +557,18 @@ properties:
               of 0-41 and is reported as quality scores, so the output
               should be fastq or fasta+qual.
               NOTE: If set, entropytrim overrides entropymask.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           # Cardinality estimation:
           cardinality:
             description: >
               (loglog) Count unique kmers using the LogLog algorithm.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           cardinalityout:
             description: >
               (loglogout) Count unique kmers in output reads.
-            $ref: #/definitions/tfbool
+            $ref: "#/definitions/tfbool"
             default: f
           loglogk:
             description: >
@@ -625,8 +623,8 @@ properties:
           dedup:
             description: >
               enable deduplication to drop the duplicated reads/pairs
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           dup_calc_accuracy:
             description: >
               accuracy level to calculate duplication (1~6), higher level uses more memory (1G, 2G, 4G, 8G, 16G, 24G). Default 1 for no-dedup mode, and 3 for dedup mode. (int [=0])
@@ -637,13 +635,13 @@ properties:
           dont_eval_duplication:
             description: >
               don't evaluate duplication rate to save time and use less memory.
-            $ref: #/definitions/tfbool
-            default: t
+            type: boolean
+            default: true
           trim_poly_g:
             description: >
               force polyG tail trimming, by default trimming is automatically enabled for Illumina NextSeq/NovaSeq data
-            $ref: #/definitions/tfbool
-            default: t
+            type: boolean
+            default: true
           poly_g_min_len:
             description: >
               the minimum length to detect polyG in the read tail. 10 by default. (int [=10])
@@ -652,8 +650,8 @@ properties:
           trim_poly_x:
             description: >
               enable polyX trimming in 3' ends.
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           poly_x_min_len:
             description: >
               the minimum length to detect polyX in the read tail. 10 by default. (int [=10])
@@ -662,18 +660,18 @@ properties:
           cut_front:
             description: >
               move a sliding window from front (5') to tail, drop the bases in the window if its mean quality < threshold, stop otherwise.
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           cut_tail:
             description: >
               move a sliding window from tail (3') to front, drop the bases in the window if its mean quality < threshold, stop otherwise.
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           cut_right:
             description: >
               move a sliding window from front to tail, if meet one window with mean quality < threshold, drop the bases in the window and the right part, and then stop.
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           cut_front_window_size:
             description: >
               the window size option of cut_front, default to cut_window_size if not specified (int [=4])
@@ -707,8 +705,8 @@ properties:
           disable_quality_filtering:
             description: >
               quality filtering is enabled by default. If this option is specified, quality filtering is disabled
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           qualified_quality_phred:
             description: >
               the quality value that a base is qualified. Default 15 means phred quality >=Q15 is qualified. (int [=15])
@@ -732,8 +730,8 @@ properties:
           disable_length_filtering:
             description: >
               length filtering is enabled by default. If this option is specified, length filtering is disabled
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           length_required:
             description: >
               reads shorter than length_required will be discarded, default is 15. (int [=15])
@@ -747,8 +745,8 @@ properties:
           low_complexity_filter:
             description: >
               enable low complexity filter. The complexity is defined as the percentage of base that is different from its next base (base[i] != base[i+1]).
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           complexity_threshold:
             description: >
               the threshold for low complexity filter (0~100). Default is 30, which means 30% complexity is required. (int [=30])
@@ -772,8 +770,8 @@ properties:
           correction:
             description: >
               enable base correction in overlapped regions (only for PE data), default is disabled
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           overlap_len_require:
             description: >
               the minimum length to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. 30 by default. (int [=30])
@@ -792,8 +790,8 @@ properties:
           umi:
             description: >
               enable unique molecular identifier (UMI) preprocessing
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
           umi_loc:
             description: >
               specify the location of UMI, can be (index1/index2/read1/read2/per_index/per_read, default is none (string [=])
@@ -820,8 +818,18 @@ properties:
           overrepresentation_analysis:
             description: >
               enable overrepresented sequence analysis.
-            $ref: #/definitions/tfbool
-            default: f
+            type: boolean
+            default: false
+
+    additionalProperties: false
+
+  required:
+    - tools
+  anyOf:
+    - required:
+      - "bbduk"
+    - required:
+      - "fastp"
 
 required:
   - adapter_trimming

--- a/snappy_pipeline/workflows/adapter_trimming/config.schema.yaml
+++ b/snappy_pipeline/workflows/adapter_trimming/config.schema.yaml
@@ -2,6 +2,11 @@ $schema: "https://json-schema.org/draft/2020-12/schema"
 
 description: configuration file for adapter_trimming step
 
+definitions:
+  tfbool:
+    type: string
+    enum: ["t", "f"]
+
 type: object
 properties:
   adapter_trimming:
@@ -39,10 +44,10 @@ properties:
           interleaved:
             description: "(int) t/f overrides interleaved autodetection."
             oneOf:
-              - type: boolean
+              - $ref: #/definitions/tfbool
               - type: string
-                enum: [ "auto" ]
-            default: auto
+                enum: [ "auto"]
+            default: "auto"
           qin:
             description: "Input quality offset: 33 (Sanger), 64, or auto."
             type: string
@@ -53,12 +58,12 @@ properties:
               (cu) Process non-AGCT IUPAC reference bases by making all
               possible unambiguous copies.  Intended for short motifs
               or adapter barcodes, as time/memory use is exponential.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           nzo:
             description: "Only write statistics about ref sequences with nonzero hits."
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
           qout:
             description: "Output quality offset: 33 (Sanger), 64, or auto."
             type: string
@@ -71,20 +76,20 @@ properties:
             default: 3
           rename:
             description: "Rename reads to indicate which sequences they matched."
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           refnames:
             description: "Use names of reference files rather than scaffold IDs."
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           trd:
             description: "Truncate read and ref names at the first whitespace."
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           ordered:
             description: "Set to true to output reads in same order as input."
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
 
           # Histogram output parameters:
           gcbins:
@@ -108,8 +113,8 @@ properties:
           # Histograms for mapped sam/bam files only:
           histbefore:
             description: "Calculate histograms from reads before processing."
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
           idbins:
             description: "Number idhist bins.  Set to 'auto' to use read length."
             oneOf:
@@ -128,16 +133,16 @@ properties:
             default: 21
           rcomp:
             description: "Look for reverse-complements of kmers in addition to forward kmers."
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
 
           # Processing parameters:
           maskmiddle:
             description: >
               (mm) Treat the middle base of a kmer as a wildcard, to
               increase sensitivity in the presence of errors.
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
           minkmerhits:
             description: >
               (mkh) Reads need at least this many matching kmers
@@ -192,41 +197,41 @@ properties:
               (fn) Forbids matching of read kmers containing N.
               By default, these will match a reference 'A' if
               hdist>0 or edist>0, to increase sensitivity.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           removeifeitherbad:
             description: >
               (rieb) Paired reads get sent to 'outmatch' if either is
               match (or either is trimmed shorter than minlen).
               Set to false to require both.
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
           trimfailures:
             description: >
               Instead of discarding failed reads, trim them to 1bp.
               This makes the statistics a bit odd.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           findbestmatch:
             description: >
               (fbm) If multiple matches, associate read with sequence
               sharing most kmers.  Reduces speed.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           skipr1:
             description: "Don't do kmer-based operations on read 1."
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           skipr2:
             description: "Don't do kmer-based operations on read 2."
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           ecco:
             description: >
               For overlapping paired reads only.  Performs error-
               correction with BBMerge prior to kmer operations.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           # Trimming/Filtering/Masking parameters:
           # Note - if ktrim, kmask, and ksplit are unset, the default behavior is kfilter.
           # All kmer processing modes are mutually exclusive.
@@ -251,8 +256,8 @@ properties:
             default: ""
           maskfullycovered:
             description: "(mfc) Only mask bases that are fully covered by kmers."
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           ksplit:
             description: >
               For single-ended reads only.  Reads will be split into
@@ -260,8 +265,8 @@ properties:
               read, it will be trimmed instead.  Singletons will go to
               out, and pairs will go to outm.  Do not use ksplit with
               other operations such as quality-trimming or filtering.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           mink:
             description: >
               Look for shorter kmers at read tips down to this length,
@@ -334,8 +339,8 @@ properties:
             description: >
               (outputtrimmedtomatch) Output reads trimmed to shorter
               than minlength to outm rather than discarding.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           tp:
             description: >
               (trimpad) Trim this much extra around matching kmers.
@@ -344,13 +349,13 @@ properties:
           tbo:
             description: >
               (trimbyoverlap) Trim adapters based on where paired reads overlap.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           strictoverlap:
             description: >
               Adjust sensitivity for trimbyoverlap mode.
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
           minoverlap:
             description: >
               Require this many bases of overlap for detection.
@@ -366,8 +371,8 @@ properties:
             description: >
               (trimpairsevenly) When kmer right-trimming, trim both
               reads to the minimum length of either.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           forcetrimleft:
             description: >
               (ftl) If positive, trim bases to the left of this position
@@ -417,25 +422,25 @@ properties:
             description: >
               Use average GC of paired reads.    Deprecated option?
               Also affects gchist.
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
           tossjunk:
             description: >
               Discard reads with invalid characters as bases.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           swift:
             description: >
               Trim Swift sequences: Trailing C/T/N R1, leading G/A/N R2.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
 
           # Header-parsing parameters - these require Illumina headers:
           chastityfilter:
             description: >
               (cf) Discard reads with id containing ' 1:Y:' or ' 2:Y:'.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           barcodefilter:
             description: |
               Remove reads with unexpected barcodes if barcodes is set,
@@ -445,11 +450,9 @@ properties:
                 t:     Remove reads with bad barcodes.
                 f:     Ignore barcodes.
                 crash: Crash upon encountering bad barcodes.
-            oneOf:
-              - type: boolean
-              - type: string
-                enum: [ "crash" ]
-            default: false
+            type: string
+            enum: [ "t", "f", "crash" ]
+            default: f
           barcodes:
             description: >
               File of barcodes.
@@ -538,11 +541,9 @@ properties:
                 l:  (left) Trim low entropy on the left end only.
                 rl: (both) Trim low entropy on both ends.
               NOTE: If set, entropytrim overrides entropymask.
-            oneOf:
-              - type: boolean
-              - type: string
-                enum: [ "f", "r", "l", "rl" ]
-            default: false
+            type: string
+            enum: [ "f", "r", "l", "rl" ]
+            default: f
           entropymask:
             description: |
               Values:
@@ -558,19 +559,19 @@ properties:
               of 0-41 and is reported as quality scores, so the output
               should be fastq or fasta+qual.
               NOTE: If set, entropytrim overrides entropymask.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           # Cardinality estimation:
           cardinality:
             description: >
               (loglog) Count unique kmers using the LogLog algorithm.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           cardinalityout:
             description: >
               (loglogout) Count unique kmers in output reads.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           loglogk:
             description: >
               Use this kmer length for counting.
@@ -624,8 +625,8 @@ properties:
           dedup:
             description: >
               enable deduplication to drop the duplicated reads/pairs
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           dup_calc_accuracy:
             description: >
               accuracy level to calculate duplication (1~6), higher level uses more memory (1G, 2G, 4G, 8G, 16G, 24G). Default 1 for no-dedup mode, and 3 for dedup mode. (int [=0])
@@ -636,13 +637,13 @@ properties:
           dont_eval_duplication:
             description: >
               don't evaluate duplication rate to save time and use less memory.
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
           trim_poly_g:
             description: >
               force polyG tail trimming, by default trimming is automatically enabled for Illumina NextSeq/NovaSeq data
-            type: boolean
-            default: true
+            $ref: #/definitions/tfbool
+            default: t
           poly_g_min_len:
             description: >
               the minimum length to detect polyG in the read tail. 10 by default. (int [=10])
@@ -651,8 +652,8 @@ properties:
           trim_poly_x:
             description: >
               enable polyX trimming in 3' ends.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           poly_x_min_len:
             description: >
               the minimum length to detect polyX in the read tail. 10 by default. (int [=10])
@@ -661,18 +662,18 @@ properties:
           cut_front:
             description: >
               move a sliding window from front (5') to tail, drop the bases in the window if its mean quality < threshold, stop otherwise.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           cut_tail:
             description: >
               move a sliding window from tail (3') to front, drop the bases in the window if its mean quality < threshold, stop otherwise.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           cut_right:
             description: >
               move a sliding window from front to tail, if meet one window with mean quality < threshold, drop the bases in the window and the right part, and then stop.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           cut_front_window_size:
             description: >
               the window size option of cut_front, default to cut_window_size if not specified (int [=4])
@@ -706,8 +707,8 @@ properties:
           disable_quality_filtering:
             description: >
               quality filtering is enabled by default. If this option is specified, quality filtering is disabled
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           qualified_quality_phred:
             description: >
               the quality value that a base is qualified. Default 15 means phred quality >=Q15 is qualified. (int [=15])
@@ -731,8 +732,8 @@ properties:
           disable_length_filtering:
             description: >
               length filtering is enabled by default. If this option is specified, length filtering is disabled
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           length_required:
             description: >
               reads shorter than length_required will be discarded, default is 15. (int [=15])
@@ -746,8 +747,8 @@ properties:
           low_complexity_filter:
             description: >
               enable low complexity filter. The complexity is defined as the percentage of base that is different from its next base (base[i] != base[i+1]).
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           complexity_threshold:
             description: >
               the threshold for low complexity filter (0~100). Default is 30, which means 30% complexity is required. (int [=30])
@@ -771,8 +772,8 @@ properties:
           correction:
             description: >
               enable base correction in overlapped regions (only for PE data), default is disabled
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           overlap_len_require:
             description: >
               the minimum length to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. 30 by default. (int [=30])
@@ -791,8 +792,8 @@ properties:
           umi:
             description: >
               enable unique molecular identifier (UMI) preprocessing
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
           umi_loc:
             description: >
               specify the location of UMI, can be (index1/index2/read1/read2/per_index/per_read, default is none (string [=])
@@ -819,8 +820,8 @@ properties:
           overrepresentation_analysis:
             description: >
               enable overrepresented sequence analysis.
-            type: boolean
-            default: false
+            $ref: #/definitions/tfbool
+            default: f
 
 required:
   - adapter_trimming

--- a/snappy_pipeline/workflows/adapter_trimming/config.schema.yaml
+++ b/snappy_pipeline/workflows/adapter_trimming/config.schema.yaml
@@ -1,0 +1,827 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+
+description: configuration file for adapter_trimming step
+
+type: object
+properties:
+  adapter_trimming:
+    type: object
+    required:
+      - tools
+    additionalProperties: false
+
+    properties:
+      path_link_in:
+        type: string
+      tools:
+        type: array
+        items:
+          type: string
+          enum: [ "bbduk", "fastp" ]
+
+      bbduk:
+        type: object
+        required:
+          - adapter_sequences
+        additionalProperties: false
+
+        properties:
+          adapter_sequences:
+            type: array
+            items:
+              type: string
+          num_threads:
+            type: integer
+            default: 8
+
+          # Non-default parameters from https://www.biostars.org/p/268221/
+          # & https://github.com/ewels/MultiQC/issues/1146#issuecomment-607980076
+          interleaved:
+            description: "(int) t/f overrides interleaved autodetection."
+            oneOf:
+              - type: boolean
+              - type: string
+                enum: [ "auto" ]
+            default: auto
+          qin:
+            description: "Input quality offset: 33 (Sanger), 64, or auto."
+            type: string
+            enum: [ "auto", "33", "64" ]
+            default: "auto"
+          copyundefined:
+            description: >
+              (cu) Process non-AGCT IUPAC reference bases by making all
+              possible unambiguous copies.  Intended for short motifs
+              or adapter barcodes, as time/memory use is exponential.
+            type: boolean
+            default: false
+          nzo:
+            description: "Only write statistics about ref sequences with nonzero hits."
+            type: boolean
+            default: true
+          qout:
+            description: "Output quality offset: 33 (Sanger), 64, or auto."
+            type: string
+            enum: [ "auto", "33", "64" ]
+            default: "auto"
+          statscolumns:
+            description: "(cols) Number of columns for stats output, 3 or 5. 5 includes base counts."
+            type: integer
+            enum: [ 3, 5 ]
+            default: 3
+          rename:
+            description: "Rename reads to indicate which sequences they matched."
+            type: boolean
+            default: false
+          refnames:
+            description: "Use names of reference files rather than scaffold IDs."
+            type: boolean
+            default: false
+          trd:
+            description: "Truncate read and ref names at the first whitespace."
+            type: boolean
+            default: false
+          ordered:
+            description: "Set to true to output reads in same order as input."
+            type: boolean
+            default: false
+
+          # Histogram output parameters:
+          gcbins:
+            description: "Number gchist bins.  Set to 'auto' to use read length."
+            oneOf:
+              - type: integer
+              - type: string
+                enum: [ "auto" ]
+            default: "auto"
+          maxhistlen:
+            description: >
+              Set an upper bound for histogram lengths; higher uses
+              more memory.  The default is 6000 for some histograms
+              and 80000 for others.
+            oneOf:
+              - type: integer
+              - type: string
+                enum: [ "auto" ]
+            default: 6000
+
+          # Histograms for mapped sam/bam files only:
+          histbefore:
+            description: "Calculate histograms from reads before processing."
+            type: boolean
+            default: true
+          idbins:
+            description: "Number idhist bins.  Set to 'auto' to use read length."
+            oneOf:
+              - type: integer
+              - type: string
+                enum: [ "auto" ]
+            default: 100
+          # Processing parameters:
+          k:
+            description: >
+              Kmer length used for finding contaminants.  Contaminants
+              shorter than k will not be found.  k must be at least 1.
+              bbduk default: 27
+            type: integer
+            minimum: 0
+            default: 21
+          rcomp:
+            description: "Look for reverse-complements of kmers in addition to forward kmers."
+            type: boolean
+            default: true
+
+          # Processing parameters:
+          maskmiddle:
+            description: >
+              (mm) Treat the middle base of a kmer as a wildcard, to
+              increase sensitivity in the presence of errors.
+            type: boolean
+            default: true
+          minkmerhits:
+            description: >
+              (mkh) Reads need at least this many matching kmers
+              to be considered as matching the reference.
+            type: integer
+            default: 1
+          minkmerfraction:
+            description: >
+              (mkf) A reads needs at least this fraction of its total
+              kmers to hit a ref, in order to be considered a match.
+              If this and minkmerhits are set, the greater is used.
+            type: number
+            default: 0.0
+          mincovfraction:
+            description: >
+              (mcf) A reads needs at least this fraction of its total
+              bases to be covered by ref kmers to be considered a match.
+              If specified, mcf overrides mkh and mkf.
+            type: number
+            default: 0.0
+          hammingdistance:
+            description: >
+              (hdist) Maximum Hamming distance for ref kmers (subs only).
+              Memory use is proportional to (3*K)^hdist.
+              bbduk default: 0
+            type: integer
+            default: 1
+          qhdist:
+            description: "Hamming distance for query kmers; impacts speed, not memory."
+            type: integer
+            default: 0
+          editdistance:
+            description: >
+              (edist) Maximum edit distance from ref kmers (subs and indels).
+              Memory use is proportional to (8*K)^edist.
+            type: integer
+            default: 0
+          hammingdistance2:
+            description: "(hdist2) Sets hdist for short kmers, when using mink."
+            type: integer
+            default: 0
+          qhdist2:
+            description: "Sets qhdist for short kmers, when using mink."
+            type: integer
+            default: 0
+          editdistance2:
+            description: "(edist2) Sets edist for short kmers, when using mink."
+            type: integer
+            default: 0
+          forbidn:
+            description: >
+              (fn) Forbids matching of read kmers containing N.
+              By default, these will match a reference 'A' if
+              hdist>0 or edist>0, to increase sensitivity.
+            type: boolean
+            default: false
+          removeifeitherbad:
+            description: >
+              (rieb) Paired reads get sent to 'outmatch' if either is
+              match (or either is trimmed shorter than minlen).
+              Set to false to require both.
+            type: boolean
+            default: true
+          trimfailures:
+            description: >
+              Instead of discarding failed reads, trim them to 1bp.
+              This makes the statistics a bit odd.
+            type: boolean
+            default: false
+          findbestmatch:
+            description: >
+              (fbm) If multiple matches, associate read with sequence
+              sharing most kmers.  Reduces speed.
+            type: boolean
+            default: false
+          skipr1:
+            description: "Don't do kmer-based operations on read 1."
+            type: boolean
+            default: false
+          skipr2:
+            description: "Don't do kmer-based operations on read 2."
+            type: boolean
+            default: false
+          ecco:
+            description: >
+              For overlapping paired reads only.  Performs error-
+              correction with BBMerge prior to kmer operations.
+            type: boolean
+            default: false
+          # Trimming/Filtering/Masking parameters:
+          # Note - if ktrim, kmask, and ksplit are unset, the default behavior is kfilter.
+          # All kmer processing modes are mutually exclusive.
+          # Reads only get sent to 'outm' purely based on kmer matches in kfilter mode.
+          ktrim:
+            description: >
+              Trim reads to remove bases matching reference kmers.
+              Values:
+                f (don't trim), [bbduk default]
+                r (trim to the right),
+                l (trim to the left)
+            type: string
+            enum: [ "f", "r", "l" ]
+            default: "r"
+          kmask:
+            description: >
+              Replace bases matching ref kmers with another symbol.
+              Allows any non-whitespace character, and processes short
+              kmers on both ends if mink is set.  'kmask: lc' will
+              convert masked bases to lowercase.
+            type: string
+            default: ""
+          maskfullycovered:
+            description: "(mfc) Only mask bases that are fully covered by kmers."
+            type: boolean
+            default: false
+          ksplit:
+            description: >
+              For single-ended reads only.  Reads will be split into
+              pairs around the kmer.  If the kmer is at the end of the
+              read, it will be trimmed instead.  Singletons will go to
+              out, and pairs will go to outm.  Do not use ksplit with
+              other operations such as quality-trimming or filtering.
+            type: boolean
+            default: false
+          mink:
+            description: >
+              Look for shorter kmers at read tips down to this length,
+              when k-trimming or masking.  0 means disabled.  Enabling
+              this will disable maskmiddle.
+              bbduk default: 0 (disabled)
+            type: integer
+            default: 11
+          qtrim:
+            description: |
+              Trim read ends to remove bases with quality below trimq.
+              Performed AFTER looking for kmers.  Values:
+                rl (trim both ends),
+                f (neither end),  [bbduk default]
+                r (right end only),
+                l (left end only),
+                w (sliding window).
+            type: string
+            enum: [ "rl", "f", "r", "l", "w" ]
+            default: rl
+          trimq:
+            description: >
+              Regions with average quality BELOW this will be trimmed,
+              if qtrim is set to something other than f.
+              Can be a floating-point number like 7.3.
+              Very strict quality threshold, bbduk default: 6
+            type: integer
+            default: 25
+          minlength:
+            description: >
+              (ml) Reads shorter than this after trimming will be discarded.
+              Pairs will be discarded if both are shorter.
+              bbduk default: 10
+            type: integer
+            default: 35
+          mlf:
+            description: >
+              (minlengthfraction) Reads shorter than this fraction of
+              original length after trimming will be discarded.
+            type: integer
+            default: 0
+          minavgquality:
+            description: >
+              (maq) Reads with average quality (after trimming) below
+              this will be discarded.
+            type: integer
+            default: 0
+          maqb:
+            description: If positive, calculate maq from this many initial bases.
+            type: integer
+            default: 0
+          minbasequality:
+            description: >
+              (mbq) Reads with any base below this quality (after trimming) will be discarded.
+            type: integer
+            default: 0
+          maxns:
+            description: >
+              If non-negative, reads with more Ns than this
+              (after trimming) will be discarded.
+            type: integer
+            default: -1
+          mcb:
+            description: >
+              (minconsecutivebases) Discard reads without at least
+              this many consecutive called bases.
+            type: integer
+            default: 0
+          ottm:
+            description: >
+              (outputtrimmedtomatch) Output reads trimmed to shorter
+              than minlength to outm rather than discarding.
+            type: boolean
+            default: false
+          tp:
+            description: >
+              (trimpad) Trim this much extra around matching kmers.
+            type: integer
+            default: 0
+          tbo:
+            description: >
+              (trimbyoverlap) Trim adapters based on where paired reads overlap.
+            type: boolean
+            default: false
+          strictoverlap:
+            description: >
+              Adjust sensitivity for trimbyoverlap mode.
+            type: boolean
+            default: true
+          minoverlap:
+            description: >
+              Require this many bases of overlap for detection.
+            type: integer
+            default: 14
+          mininsert:
+            description: >
+              Require insert size of at least this for overlap.
+              Should be reduced to 16 for small RNA sequencing.
+            type: integer
+            default: 40
+          tpe:
+            description: >
+              (trimpairsevenly) When kmer right-trimming, trim both
+              reads to the minimum length of either.
+            type: boolean
+            default: false
+          forcetrimleft:
+            description: >
+              (ftl) If positive, trim bases to the left of this position
+              (exclusive, 0-based).
+            type: integer
+            default: 0
+          forcetrimright:
+            description: >
+              (ftr) If positive, trim bases to the right of this position
+              (exclusive, 0-based).
+            type: integer
+            default: 0
+          forcetrimright2:
+            description: >
+              (ftr2) If positive, trim this many bases on the right end.
+            type: integer
+            default: 0
+          forcetrimmod:
+            description: >
+              (ftm) If positive, right-trim length to be equal to zero,
+              modulo this number.
+              bbduk default: 0
+            type: integer
+            default: 5
+          restrictleft:
+            description: >
+              If positive, only look for kmer matches in the
+              leftmost X bases.
+            type: integer
+            default: 0
+          restrictright:
+            description: >
+              If positive, only look for kmer matches in the rightmost X bases.
+            type: integer
+            default: 0
+          mingc:
+            description: >
+              Discard reads with GC content below this.
+            type: number
+            default: 0
+          maxgc:
+            description: >
+              Discard reads with GC content above this.
+            type: number
+            default: 1
+          gcpairs:
+            description: >
+              Use average GC of paired reads.    Deprecated option?
+              Also affects gchist.
+            type: boolean
+            default: true
+          tossjunk:
+            description: >
+              Discard reads with invalid characters as bases.
+            type: boolean
+            default: false
+          swift:
+            description: >
+              Trim Swift sequences: Trailing C/T/N R1, leading G/A/N R2.
+            type: boolean
+            default: false
+
+          # Header-parsing parameters - these require Illumina headers:
+          chastityfilter:
+            description: >
+              (cf) Discard reads with id containing ' 1:Y:' or ' 2:Y:'.
+            type: boolean
+            default: false
+          barcodefilter:
+            description: |
+              Remove reads with unexpected barcodes if barcodes is set,
+              or barcodes containing 'N' otherwise.
+              A barcode must be the last part of the read header.
+              Values:
+                t:     Remove reads with bad barcodes.
+                f:     Ignore barcodes.
+                crash: Crash upon encountering bad barcodes.
+            oneOf:
+              - type: boolean
+              - type: string
+                enum: [ "crash" ]
+            default: false
+          barcodes:
+            description: >
+              File of barcodes.
+            type: string
+            default: ""
+          xmin:
+            description: >
+              If positive, discard reads with a lesser X coordinate.
+            type: integer
+            default: -1
+          ymin:
+            description: >
+              If positive, discard reads with a lesser Y coordinate.
+            type: integer
+            default: -1
+          xmax:
+            description: >
+              If positive, discard reads with a greater X coordinate.
+            type: integer
+            default: -1
+          ymax:
+            description: >
+              If positive, discard reads with a greater Y coordinate.
+            type: integer
+            default: -1
+
+          # Polymer trimming:
+          trimpolya:
+            description: >
+              If greater than 0, trim poly-A or poly-T tails of
+              at least this length on either end of reads.
+            type: integer
+            default: 0
+          trimpolygleft:
+            description: >
+              If greater than 0, trim poly-G prefixes of at least this
+              length on the left end of reads.  Does not trim poly-C.
+            type: integer
+            default: 0
+          trimpolygright:
+            description: >
+              If greater than 0, trim poly-G tails of at least this
+              length on the right end of reads.  Does not trim poly-C.
+              bbduk default: don't trim polyG (trimpolyg=0)
+            type: integer
+            default: 8
+          trimpolyg:
+            description: >
+              This sets both left and right at once.
+            type: integer
+            default: 0
+          filterpolyg:
+            description: >
+              If greater than 0, remove reads with a poly-G prefix of
+              at least this length (on the left).
+              Note: there are also equivalent poly-C flags.
+            type: integer
+            default: 8
+          # Entropy/Complexity parameters:
+          entropy:
+            description: >
+              Set between 0 and 1 to filter reads with entropy below
+              that value.  Higher is more stringent.
+            type: number
+            default: -1
+          entropywindow:
+            description: >
+              Calculate entropy using a sliding window of this length.
+            type: integer
+            default: 50
+          entropyk:
+            description: >
+              Calculate entropy using kmers of this length.
+            type: integer
+            default: 5
+          minbasefrequency:
+            description: >
+              Discard reads with a minimum base frequency below this.
+            type: number
+            default: 0
+          entropytrim:
+            description: |
+              Values:
+                f:  (false) Do not entropy-trim.
+                r:  (right) Trim low entropy on the right end only.
+                l:  (left) Trim low entropy on the left end only.
+                rl: (both) Trim low entropy on both ends.
+              NOTE: If set, entropytrim overrides entropymask.
+            oneOf:
+              - type: boolean
+              - type: string
+                enum: [ "f", "r", "l", "rl" ]
+            default: false
+          entropymask:
+            description: |
+              Values:
+                f:  (filter) Discard low-entropy sequences.
+                t:  (true) Mask low-entropy parts of sequences with N.
+                lc: Change low-entropy parts of sequences to lowercase.
+            type: string
+            enum: [ "f", "t", "lc" ]
+            default: f
+          entropymark:
+            description: >
+              Mark each base with its entropy value.  This is on a scale
+              of 0-41 and is reported as quality scores, so the output
+              should be fastq or fasta+qual.
+              NOTE: If set, entropytrim overrides entropymask.
+            type: boolean
+            default: false
+          # Cardinality estimation:
+          cardinality:
+            description: >
+              (loglog) Count unique kmers using the LogLog algorithm.
+            type: boolean
+            default: false
+          cardinalityout:
+            description: >
+              (loglogout) Count unique kmers in output reads.
+            type: boolean
+            default: false
+          loglogk:
+            description: >
+              Use this kmer length for counting.
+            type: integer
+            minimum: 0
+            default: 31
+          loglogbuckets:
+            description: >
+              Use this many buckets for counting.
+            type: integer
+            minimum: 0
+            default: 2048
+
+      # fastp configuration options
+      fastp:
+        type: object
+        properties:
+          num_threads:
+            type: integer
+            default: 0
+          trim_front1:
+            description: >
+              trimming how many bases in front for read1, default is 0 (int [=0])
+            type: integer
+            default: 0
+          trim_tail1:
+            description: >
+              trimming how many bases in tail for read1, default is 0 (int [=0])
+            type: integer
+            default: 0
+          max_len1:
+            description: >
+              if read1 is longer than max_len1, then trim read1 at its tail to make it as long as max_len1. Default 0 means no limitation (int [=0])
+            type: integer
+            default: 0
+          trim_front2:
+            description: >
+              trimming how many bases in front for read2. If it's not specified, it will follow read1's settings (int [=0])
+            type: integer
+            default: 0
+          trim_tail2:
+            description: >
+              trimming how many bases in tail for read2. If it's not specified, it will follow read1's settings (int [=0])
+            type: integer
+            default: 0
+          max_len2:
+            description: >
+              if read2 is longer than max_len2, then trim read2 at its tail to make it as long as max_len2. Default 0 means no limitation. If it's not specified, it will follow read1's settings (int [=0])
+            type: integer
+            default: 0
+          dedup:
+            description: >
+              enable deduplication to drop the duplicated reads/pairs
+            type: boolean
+            default: false
+          dup_calc_accuracy:
+            description: >
+              accuracy level to calculate duplication (1~6), higher level uses more memory (1G, 2G, 4G, 8G, 16G, 24G). Default 1 for no-dedup mode, and 3 for dedup mode. (int [=0])
+            type: integer
+            minimum: 0
+            maximum: 6
+            default: 0
+          dont_eval_duplication:
+            description: >
+              don't evaluate duplication rate to save time and use less memory.
+            type: boolean
+            default: true
+          trim_poly_g:
+            description: >
+              force polyG tail trimming, by default trimming is automatically enabled for Illumina NextSeq/NovaSeq data
+            type: boolean
+            default: true
+          poly_g_min_len:
+            description: >
+              the minimum length to detect polyG in the read tail. 10 by default. (int [=10])
+            type: integer
+            default: 8
+          trim_poly_x:
+            description: >
+              enable polyX trimming in 3' ends.
+            type: boolean
+            default: false
+          poly_x_min_len:
+            description: >
+              the minimum length to detect polyX in the read tail. 10 by default. (int [=10])
+            type: integer
+            default: 10
+          cut_front:
+            description: >
+              move a sliding window from front (5') to tail, drop the bases in the window if its mean quality < threshold, stop otherwise.
+            type: boolean
+            default: false
+          cut_tail:
+            description: >
+              move a sliding window from tail (3') to front, drop the bases in the window if its mean quality < threshold, stop otherwise.
+            type: boolean
+            default: false
+          cut_right:
+            description: >
+              move a sliding window from front to tail, if meet one window with mean quality < threshold, drop the bases in the window and the right part, and then stop.
+            type: boolean
+            default: false
+          cut_front_window_size:
+            description: >
+              the window size option of cut_front, default to cut_window_size if not specified (int [=4])
+            type: integer
+            default: 4
+          cut_front_mean_quality:
+            description: >
+              the mean quality requirement option for cut_front, default to cut_mean_quality if not specified (int [=20])
+            type: integer
+            default: 20
+          cut_tail_window_size:
+            description: >
+              the window size option of cut_tail, default to cut_window_size if not specified (int [=4])
+            type: integer
+            default: 4
+          cut_tail_mean_quality:
+            description: >
+              the mean quality requirement option for cut_tail, default to cut_mean_quality if not specified (int [=20])
+            type: integer
+            default: 20
+          cut_right_window_size:
+            description: >
+              the window size option of cut_right, default to cut_window_size if not specified (int [=4])
+            type: integer
+            default: 4
+          cut_right_mean_quality:
+            description: >
+              the mean quality requirement option for cut_right, default to cut_mean_quality if not specified (int [=20])
+            type: integer
+            default: 20
+          disable_quality_filtering:
+            description: >
+              quality filtering is enabled by default. If this option is specified, quality filtering is disabled
+            type: boolean
+            default: false
+          qualified_quality_phred:
+            description: >
+              the quality value that a base is qualified. Default 15 means phred quality >=Q15 is qualified. (int [=15])
+            type: integer
+            default: 15
+          unqualified_percent_limit:
+            description: >
+              how many percents of bases are allowed to be unqualified (0~100). Default 40 means 40% (int [=40])
+            type: integer
+            default: 40
+          n_base_limit:
+            description: >
+              if one read's number of N base is >n_base_limit, then this read/pair is discarded. Default is 5 (int [=5])
+            type: integer
+            default: 5
+          average_qual:
+            description: >
+              if one read's average quality score <avg_qual, then this read/pair is discarded. Default 0 means no requirement (int [=0])
+            type: integer
+            default: 0
+          disable_length_filtering:
+            description: >
+              length filtering is enabled by default. If this option is specified, length filtering is disabled
+            type: boolean
+            default: false
+          length_required:
+            description: >
+              reads shorter than length_required will be discarded, default is 15. (int [=15])
+            type: integer
+            default: 15
+          length_limit:
+            description: >
+              reads longer than length_limit will be discarded, default 0 means no limitation. (int [=0])
+            type: integer
+            default: 0
+          low_complexity_filter:
+            description: >
+              enable low complexity filter. The complexity is defined as the percentage of base that is different from its next base (base[i] != base[i+1]).
+            type: boolean
+            default: false
+          complexity_threshold:
+            description: >
+              the threshold for low complexity filter (0~100). Default is 30, which means 30% complexity is required. (int [=30])
+            type: integer
+            default: 30
+          filter_by_index1:
+            description: >
+              specify a file contains a list of barcodes of index1 to be filtered out, one barcode per line (string [=])
+            type: string
+            default: ""
+          filter_by_index2:
+            description: >
+              specify a file contains a list of barcodes of index2 to be filtered out, one barcode per line (string [=])
+            type: string
+            default: ""
+          filter_by_index_threshold:
+            description: >
+              the allowed difference of index barcode for index filtering, default 0 means completely identical. (int [=0])
+            type: integer
+            default: 0
+          correction:
+            description: >
+              enable base correction in overlapped regions (only for PE data), default is disabled
+            type: boolean
+            default: false
+          overlap_len_require:
+            description: >
+              the minimum length to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. 30 by default. (int [=30])
+            type: integer
+            default: 30
+          overlap_diff_limit:
+            description: >
+              the maximum number of mismatched bases to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. 5 by default. (int [=5])
+            type: integer
+            default: 5
+          overlap_diff_percent_limit:
+            description: >
+              the maximum percentage of mismatched bases to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. Default 20 means 20%. (int [=20])
+            type: integer
+            default: 20
+          umi:
+            description: >
+              enable unique molecular identifier (UMI) preprocessing
+            type: boolean
+            default: false
+          umi_loc:
+            description: >
+              specify the location of UMI, can be (index1/index2/read1/read2/per_index/per_read, default is none (string [=])
+            type: string
+            enum: [ "index1", "index2", "read1", "read2", "per_index", "per_read", "" ]
+            default: ""
+          umi_len:
+            description: >
+              if the UMI is in read1/read2, its length should be provided (int [=0])
+            type: integer
+            default: 0
+          umi_prefix:
+            description: >
+              if specified, an underline will be used to connect prefix and UMI (i.e. prefix=UMI, UMI=AATTCG, final=UMI_AATTCG). No prefix by default (string [=])
+            type: string
+            default: ""
+            examples:
+              - UMI
+          umi_skip:
+            description: >
+              if the UMI is in read1/read2, fastp can skip several bases following UMI, default is 0 (int [=0])
+            type: integer
+            default: 0
+          overrepresentation_analysis:
+            description: >
+              enable overrepresented sequence analysis.
+            type: boolean
+            default: false
+
+required:
+  - adapter_trimming
+additionalProperties: false


### PR DESCRIPTION
This PR aims to introduce config.yaml schema validation; that way, configuration errors can be detected easily.
Also, in principle, the default configs could simply be generated from the schema files.

I have only done this for the adapter_trimming configuration yet, just to serve as an example.