### PR TITLE
fix: explicitly require gawk in mutect2/filter wrapper environment

### DIFF
--- a/snappy_wrappers/wrappers/mutect2/environment.yaml
+++ b/snappy_wrappers/wrappers/mutect2/environment.yaml
@@ -8,6 +8,7 @@ dependencies:
 - htslib >=1.9
 - bcftools >=1.9
 - datrie
+- gawk =5.1
 # snakemake needed by the parallel wrapper
 - snakemake-minimal =7
 # needed by snakemake


### PR DESCRIPTION
The mutect2/filter wrapper requires the gawk version of `match(…)`, so this PR explicitly requires gawk in the conda environment.