### PR TITLE
fix: missing check for `has_annotation` in somatic_variant_filtration rules

### DIFF
--- a/snappy_pipeline/workflows/somatic_variant_filtration/__init__.py
+++ b/snappy_pipeline/workflows/somatic_variant_filtration/__init__.py
@@ -508,12 +508,7 @@ class DkfzBiasFilterStepPart(SomaticVariantFiltrationStepPart):
             name_pattern += ".{annotator}"
 
         # VCF file and index
-        tpl = (
-            f"output/{name_pattern}."
-            "{tumor_library}/"
-            f"out/{name_pattern}."
-            "{tumor_library}"
-        )
+        tpl = f"output/{name_pattern}." "{tumor_library}/" f"out/{name_pattern}." "{tumor_library}"
         key_ext = {"vcf": ".vcf.gz", "vcf_tbi": ".vcf.gz.tbi"}
         somatic_variant = self.parent.sub_workflows["somatic_variant"]
         for key, ext in key_ext.items():

--- a/snappy_pipeline/workflows/somatic_variant_filtration/__init__.py
+++ b/snappy_pipeline/workflows/somatic_variant_filtration/__init__.py
@@ -502,10 +502,17 @@ class DkfzBiasFilterStepPart(SomaticVariantFiltrationStepPart):
         """Return path to jannovar-annotated vcf input file"""
         # Validate action
         self._validate_action(action)
+
+        name_pattern = "{mapper}.{var_caller}"
+        if self.config["has_annotation"]:
+            name_pattern += ".{annotator}"
+
         # VCF file and index
         tpl = (
-            "output/{mapper}.{var_caller}.{annotator}.{tumor_library}/out/"
-            "{mapper}.{var_caller}.{annotator}.{tumor_library}"
+            f"output/{name_pattern}."
+            "{tumor_library}/"
+            f"out/{name_pattern}."
+            "{tumor_library}"
         )
         key_ext = {"vcf": ".vcf.gz", "vcf_tbi": ".vcf.gz.tbi"}
         somatic_variant = self.parent.sub_workflows["somatic_variant"]
@@ -523,10 +530,16 @@ class DkfzBiasFilterStepPart(SomaticVariantFiltrationStepPart):
         """Return output files for the filtration"""
         # Validate action
         self._validate_action(action)
+
+        name_pattern = "{mapper}.{var_caller}"
+        if self.config["has_annotation"]:
+            name_pattern += ".{annotator}"
+
         prefix = (
-            r"work/{mapper}.{var_caller}.{annotator}."
-            r"dkfz_bias_filter.{tumor_library,[^\.]+}/out/{mapper}.{var_caller}."
-            r"{annotator}.dkfz_bias_filter.{tumor_library}"
+            rf"work/{name_pattern}."
+            r"dkfz_bias_filter.{tumor_library,[^\.]+}/"
+            rf"out/{name_pattern}."
+            r"dkfz_bias_filter.{tumor_library}"
         )
         key_ext = {
             "vcf": ".vcf.gz",
@@ -588,11 +601,15 @@ class EbFilterStepPart(SomaticVariantFiltrationStepPart):
 
     @dictify
     def _get_input_files_run(self, wildcards):
+        name_pattern = "{mapper}.{var_caller}"
+        if self.config["has_annotation"]:
+            name_pattern += ".{annotator}"
         # VCF file and index
         tpl = (
-            "work/{mapper}.{var_caller}.{annotator}."
-            "dkfz_bias_filter.{tumor_library}/out/{mapper}.{var_caller}."
-            "{annotator}.dkfz_bias_filter."
+            f"work/{name_pattern}."
+            "dkfz_bias_filter.{tumor_library}/"
+            f"out/{name_pattern}."
+            "dkfz_bias_filter."
             "{tumor_library}"
         )
         key_ext = {"vcf": ".vcf.gz", "vcf_tbi": ".vcf.gz.tbi"}
@@ -619,10 +636,14 @@ class EbFilterStepPart(SomaticVariantFiltrationStepPart):
 
     @dictify
     def _get_output_files_run(self):
+        name_pattern = "{mapper}.{var_caller}"
+        if self.config["has_annotation"]:
+            name_pattern += ".{annotator}"
+        # VCF file and index
         prefix = (
-            r"work/{mapper}.{var_caller}.{annotator}."
-            r"dkfz_bias_filter.eb_filter.{tumor_library,[^\.]+}/out/"
-            r"{mapper}.{var_caller}.{annotator}."
+            rf"work/{name_pattern}."
+            r"dkfz_bias_filter.eb_filter.{tumor_library,[^\.]+}/"
+            rf"out/{name_pattern}."
             r"dkfz_bias_filter.eb_filter.{tumor_library}"
         )
         key_ext = {


### PR DESCRIPTION
Some filter rules in the somatic_variant_filtration workflow were missing checks for `has_annotation` to construct the correct input/output/log paths. This PR fixes that.