### PR TITLE
fix: set locale to C in bcftools/TMB wrapper

### DIFF
--- a/snappy_wrappers/wrappers/bcftools/TMB/wrapper.py
+++ b/snappy_wrappers/wrappers/bcftools/TMB/wrapper.py
@@ -26,6 +26,9 @@ exec 2> >(tee -a "{snakemake.log.log}")
 set -x
 # -----------------------------------------------------------------------------
 
+# Ensure locale is set to C, such that the printf %f calls work correctly
+export LC_ALL=C
+
 # Write out information about conda installation
 conda list > {snakemake.log.conda_list}
 conda info > {snakemake.log.conda_info}


### PR DESCRIPTION
When the user's locale was set to one that uses `,` instead of `.` as a decimal point, the wrapper would fail.