### PR TITLE
fix: move config access in gcnv/contig_ploidy wrapper to params

### DIFF
--- a/snappy_pipeline/workflows/sv_calling_targeted/__init__.py
+++ b/snappy_pipeline/workflows/sv_calling_targeted/__init__.py
@@ -103,6 +103,22 @@ class GcnvTargetedStepPart(RunGcnvStepPart):
         # Take shortcut from library to library kit.
         self.ngs_library_to_kit = self.parent.ngs_library_to_kit
 
+    def get_params(self, action: str):
+        param_fn = super().get_params(action)
+
+        def _get_params(*args, **kwargs):
+            params = param_fn(*args, **kwargs)
+            if action == "contig_ploidy":
+                par_intervals = (
+                    self.config.get("helper_gcnv_model_targeted", {})
+                    .get("gcnv", {})
+                    .get("path_par_intervals", "")
+                )
+                params.update({"par_intervals": par_intervals})
+            return params
+
+        return _get_params
+
 
 class SvCallingTargetedWorkflow(BaseStep):
     """Perform germline targeted sequencing CNV calling"""

--- a/snappy_pipeline/workflows/sv_calling_wgs/__init__.py
+++ b/snappy_pipeline/workflows/sv_calling_wgs/__init__.py
@@ -127,6 +127,23 @@ class GcnvWgsStepPart(RunGcnvStepPart):
             if donor.dna_ngs_library:
                 yield donor.dna_ngs_library.name, "wgs"
 
+    def get_params(self, action: str):
+        param_fn = super().get_params(action)
+
+        def _get_params(*args, **kwargs):
+            params = param_fn(*args, **kwargs)
+            if action == "contig_ploidy":
+                par_intervals = (
+                    self.config.get("helper_gcnv_model_wgs", {})
+                    .get("gcnv", {})
+                    .get("path_par_intervals", "")
+                )
+                params.update({"par_intervals": par_intervals})
+            params.update({"par_intervals": par_intervals})
+            return params
+
+        return _get_params
+
 
 def escape_dots_dashes(s: str) -> str:
     """Escape dots and dashes with double-underscore constructs."""

--- a/snappy_wrappers/wrappers/gcnv/contig_ploidy/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/contig_ploidy/wrapper.py
@@ -26,9 +26,7 @@ ploidy_y = {MALE: 1, FEMALE: 0}
 paths_tsv = " ".join(snakemake.input.tsv)
 
 # Add interval block list for PAR regions if configured.
-par_intervals = snakemake.config["step_config"]["helper_gcnv_model_targeted"]["gcnv"].get(
-    "path_par_intervals"
-)
+par_intervals = snakemake.params.get("par_intervals", "")
 if par_intervals:
     par_args = f"-XL {par_intervals}"
 else:

--- a/tests/snappy_pipeline/workflows/test_workflows_sv_calling_targeted.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_sv_calling_targeted.py
@@ -667,11 +667,11 @@ def test_gcnv_get_params_ploidy_model(sv_calling_targeted_workflow):
     wildcards = Wildcards(fromdict={"library_kit": "Agilent_SureSelect_Human_All_Exon_V6"})
     wildcards_fake = Wildcards(fromdict={"library_kit": "__not_a_library_kit__"})
     # Test large cohort - model defined in config
-    expected = {"model": "/path/to/ploidy-model"}
+    expected = {"model": "/path/to/ploidy-model", "par_intervals": ""}
     actual = sv_calling_targeted_workflow.get_params("gcnv", "contig_ploidy")(wildcards)
     assert actual == expected
     # Test large cohort - model not defined in config
-    expected = {"model": "__no_ploidy_model_for_library_in_config__"}
+    expected = {"model": "__no_ploidy_model_for_library_in_config__", "par_intervals": ""}
     actual = sv_calling_targeted_workflow.get_params("gcnv", "contig_ploidy")(wildcards_fake)
     assert actual == expected
 


### PR DESCRIPTION
Fixes #500 
@Nicolai-vKuegelgen this is just a suggestion, let me know if it makes sense to you. It's a little bit of code duplication that could probably be avoided by somehow obtaining the step_name within `RunGcnvStepPart`. Also I am not at all sure about the config paths I put in there.