### PR TITLE
chore: add nodefaults to conda env.yaml channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ docs/step/DEFAULT_CONFIG_*.rst
 
 # Test directory
 work/
+.tests/

--- a/snappy_wrappers/wrappers/alfred/qc/environment.yaml
+++ b/snappy_wrappers/wrappers/alfred/qc/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bedtools==2.31.1
   - alfred==0.2.8

--- a/snappy_wrappers/wrappers/arcashla/environment.yaml
+++ b/snappy_wrappers/wrappers/arcashla/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - arcas-hla==0.6.0

--- a/snappy_wrappers/wrappers/arriba/environment.yaml
+++ b/snappy_wrappers/wrappers/arriba/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - star==2.7.11b
   - trimadap==r11

--- a/snappy_wrappers/wrappers/ascat/build_baf/environment.yaml
+++ b/snappy_wrappers/wrappers/ascat/build_baf/environment.yaml
@@ -1,7 +1,8 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- bcftools ==1.5
-- samtools ==1.5
-- htslib ==1.5
+  - bcftools ==1.5
+  - samtools ==1.5
+  - htslib ==1.5

--- a/snappy_wrappers/wrappers/ascat/build_cnv/environment.yaml
+++ b/snappy_wrappers/wrappers/ascat/build_cnv/environment.yaml
@@ -1,7 +1,8 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- bcftools ==1.5
-- samtools ==1.5
-- htslib ==1.5
+  - bcftools ==1.5
+  - samtools ==1.5
+  - htslib ==1.5

--- a/snappy_wrappers/wrappers/ascat/build_cnv_from_copywriter/environment.yaml
+++ b/snappy_wrappers/wrappers/ascat/build_cnv_from_copywriter/environment.yaml
@@ -1,8 +1,9 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- bcftools ==1.5
-- samtools ==1.5
-- htslib ==1.5
+  - bcftools ==1.5
+  - samtools ==1.5
+  - htslib ==1.5
 

--- a/snappy_wrappers/wrappers/ascat/run_ascat/environment.yaml
+++ b/snappy_wrappers/wrappers/ascat/run_ascat/environment.yaml
@@ -1,9 +1,10 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- r-base==3.3.2
-- ascat==2.5
-- bcftools==1.5
-- samtools==1.5
-- htslib==1.5
+  - r-base==3.3.2
+  - ascat==2.5
+  - bcftools==1.5
+  - samtools==1.5
+  - htslib==1.5

--- a/snappy_wrappers/wrappers/baf_file_generation/environment.yaml
+++ b/snappy_wrappers/wrappers/baf_file_generation/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.15.1
   - htslib==1.15.1

--- a/snappy_wrappers/wrappers/bbduk/environment.yaml
+++ b/snappy_wrappers/wrappers/bbduk/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bbmap==39.06
   - openjdk==20.0.2

--- a/snappy_wrappers/wrappers/bcftools/call_joint/environment.yaml
+++ b/snappy_wrappers/wrappers/bcftools/call_joint/environment.yaml
@@ -1,8 +1,9 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- parallel ==20160622
-- bcftools ==1.5
-- samtools ==1.5
-- htslib ==1.5
+  - parallel ==20160622
+  - bcftools ==1.5
+  - samtools ==1.5
+  - htslib ==1.5

--- a/snappy_wrappers/wrappers/bcftools/environment.yaml
+++ b/snappy_wrappers/wrappers/bcftools/environment.yaml
@@ -1,6 +1,7 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- bcftools ==1.15.1
-- htslib ==1.15.1
+  - bcftools ==1.15.1
+  - htslib ==1.15.1

--- a/snappy_wrappers/wrappers/bcftools_call/environment.yaml
+++ b/snappy_wrappers/wrappers/bcftools_call/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - gatk4==4.5.0.0
   - parallel==20221122

--- a/snappy_wrappers/wrappers/bcftools_roh/environment.yaml
+++ b/snappy_wrappers/wrappers/bcftools_roh/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.15
   - htslib==1.15

--- a/snappy_wrappers/wrappers/bcftools_stats/run/environment.yaml
+++ b/snappy_wrappers/wrappers/bcftools_stats/run/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.3.1
   - htslib==1.3.2

--- a/snappy_wrappers/wrappers/bed_jaccard_operations/environment.yaml
+++ b/snappy_wrappers/wrappers/bed_jaccard_operations/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bedtools==2.26.0

--- a/snappy_wrappers/wrappers/bed_venn/environment.yaml
+++ b/snappy_wrappers/wrappers/bed_venn/environment.yaml
@@ -1,5 +1,6 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- bedtools ==2.26.0
+  - bedtools ==2.26.0

--- a/snappy_wrappers/wrappers/bwa/environment.yaml
+++ b/snappy_wrappers/wrappers/bwa/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bwa==0.7.17
   - samtools==1.16.1

--- a/snappy_wrappers/wrappers/bwa_mem2/environment.yaml
+++ b/snappy_wrappers/wrappers/bwa_mem2/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bwa-mem2==2.2.1
   - samtools==1.16.1

--- a/snappy_wrappers/wrappers/canvas/somatic_wgs/environment.yaml
+++ b/snappy_wrappers/wrappers/canvas/somatic_wgs/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.4.1

--- a/snappy_wrappers/wrappers/cbioportal/generate_cna/environment.yaml
+++ b/snappy_wrappers/wrappers/cbioportal/generate_cna/environment.yaml
@@ -3,7 +3,7 @@ name: generate_cna
 channels:
   - conda-forge
   - bioconda
-
+  - nodefaults
 dependencies:
   - r-base==4.3.3
   - r-tidyverse==2.0.0

--- a/snappy_wrappers/wrappers/cbioportal/merge_tables/environment.yaml
+++ b/snappy_wrappers/wrappers/cbioportal/merge_tables/environment.yaml
@@ -3,7 +3,7 @@ name: merge_tables
 channels:
   - conda-forge
   - bioconda
-
+  - nodefaults
 dependencies:
   - r-base==4.3.3
   - r-tidyverse==2.0.0

--- a/snappy_wrappers/wrappers/cnvetti/on_target/coverage/environment.yaml
+++ b/snappy_wrappers/wrappers/cnvetti/on_target/coverage/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - cnvetti==0.2.0
   - bcftools==1.9

--- a/snappy_wrappers/wrappers/cnvetti/on_target/postprocess/environment.yaml
+++ b/snappy_wrappers/wrappers/cnvetti/on_target/postprocess/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==4.2
   - r-rcpp==1.0.12

--- a/snappy_wrappers/wrappers/cnvetti/wgs/environment.yaml
+++ b/snappy_wrappers/wrappers/cnvetti/wgs/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - cnvetti==0.2.0
   - bcftools==1.9

--- a/snappy_wrappers/wrappers/cnvkit/environment.yaml
+++ b/snappy_wrappers/wrappers/cnvkit/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==3.10.14
   - cnvkit==0.9.10

--- a/snappy_wrappers/wrappers/cnvkit/postprocess/environment.yaml
+++ b/snappy_wrappers/wrappers/cnvkit/postprocess/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==4.3.3
   - bioconductor-genomicranges==1.54.1

--- a/snappy_wrappers/wrappers/control_freec/environment.yaml
+++ b/snappy_wrappers/wrappers/control_freec/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - control-freec==11.6
   - sambamba==1.0

--- a/snappy_wrappers/wrappers/control_freec/transform/environment.yaml
+++ b/snappy_wrappers/wrappers/control_freec/transform/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==4.3.3
   - r-tidyverse==2.0.0

--- a/snappy_wrappers/wrappers/copywriter/environment.yaml
+++ b/snappy_wrappers/wrappers/copywriter/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==3.6
   - r-rcpp==1.0.6

--- a/snappy_wrappers/wrappers/defuse/environment.yaml
+++ b/snappy_wrappers/wrappers/defuse/environment.yaml
@@ -1,6 +1,7 @@
 channels:
-- conda-forge
-- bioconda
-- https://conda.anaconda.org/dranew
+  - conda-forge
+  - bioconda
+  - https://conda.anaconda.org/dranew
+  - nodefaults
 dependencies:
-- defuse ==0.8.1
+  - defuse ==0.8.1

--- a/snappy_wrappers/wrappers/delly2/germline/environment.yaml
+++ b/snappy_wrappers/wrappers/delly2/germline/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.19
   - htslib==1.19.1

--- a/snappy_wrappers/wrappers/delly2/germline_cnv/environment.yaml
+++ b/snappy_wrappers/wrappers/delly2/germline_cnv/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.19
   - htslib==1.19.1

--- a/snappy_wrappers/wrappers/dkfz_bias_filter/environment.yaml
+++ b/snappy_wrappers/wrappers/dkfz_bias_filter/environment.yaml
@@ -1,8 +1,9 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- htslib ==1.3.1
-- dkfz-bias-filter ==1.2.3a
-# bcftools incompatible with dkfz-bias-filter in bioconda (2023-10-13)
-# - bcftools
+  - htslib ==1.3.1
+  - dkfz-bias-filter ==1.2.3a
+  # bcftools incompatible with dkfz-bias-filter in bioconda (2023-10-13)
+  # - bcftools

--- a/snappy_wrappers/wrappers/dupradar/environment.yaml
+++ b/snappy_wrappers/wrappers/dupradar/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==4.3
   - bioconductor-dupradar==1.32.0

--- a/snappy_wrappers/wrappers/eb_filter/environment.yaml
+++ b/snappy_wrappers/wrappers/eb_filter/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - ebfilter==0.2.2
   - vcfpy==0.13.8

--- a/snappy_wrappers/wrappers/eb_filter_par/environment.yaml
+++ b/snappy_wrappers/wrappers/eb_filter_par/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda
+  - nodefaults
 dependencies:
   - ebfilter==0.2.2
   - vcfpy==0.13.8

--- a/snappy_wrappers/wrappers/epitoper/environment.yaml
+++ b/snappy_wrappers/wrappers/epitoper/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda/
+  - nodefaults
 dependencies:
   - netmhccons==1.1a
   - epitoper==0.3

--- a/snappy_wrappers/wrappers/epitoper_par/environment.yaml
+++ b/snappy_wrappers/wrappers/epitoper_par/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - zlib==1.3.1

--- a/snappy_wrappers/wrappers/expansionhunter/environment.yaml
+++ b/snappy_wrappers/wrappers/expansionhunter/environment.yaml
@@ -1,4 +1,6 @@
 channels:
+  - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - expansionhunter==3.2.2

--- a/snappy_wrappers/wrappers/fastp/environment.yaml
+++ b/snappy_wrappers/wrappers/fastp/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - fastp==0.23.4

--- a/snappy_wrappers/wrappers/fastqc/environment.yaml
+++ b/snappy_wrappers/wrappers/fastqc/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - perl ==5.32.1
   - fastqc ==0.11.9

--- a/snappy_wrappers/wrappers/featurecounts/environment.yaml
+++ b/snappy_wrappers/wrappers/featurecounts/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - subread==1.6.0
   - samtools==1.9

--- a/snappy_wrappers/wrappers/flag_oxog_artifacts/environment.yaml
+++ b/snappy_wrappers/wrappers/flag_oxog_artifacts/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bedtools==2.31.1
   - bcftools==1.19

--- a/snappy_wrappers/wrappers/fusioncatcher/run/environment.yaml
+++ b/snappy_wrappers/wrappers/fusioncatcher/run/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==2.7.15
   - samtools==0.1.19

--- a/snappy_wrappers/wrappers/gatk3_ug/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk3_ug/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - gatk==3.8
   - gatk4==4.3.0.0

--- a/snappy_wrappers/wrappers/gatk4_hc/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk4_hc/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - gatk4==4.5.0.0
   - bcftools==1.16

--- a/snappy_wrappers/wrappers/gatk_hc_par/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_hc_par/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda
+  - nodefaults
 dependencies:
   - gatk_nonfree==3.7
   - bcftools==1.12

--- a/snappy_wrappers/wrappers/gatk_phase_by_transmission/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_phase_by_transmission/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda
+  - nodefaults
 dependencies:
   - gatk_nonfree==3.7
   - bcftools==1.9

--- a/snappy_wrappers/wrappers/gatk_read_backed_phasing/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_read_backed_phasing/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda
+  - nodefaults
 dependencies:
   - gatk_nonfree==3.7
   - bcftools==1.9

--- a/snappy_wrappers/wrappers/gatk_read_backed_phasing_par/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_read_backed_phasing_par/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda
+  - nodefaults
 dependencies:
   - gatk_nonfree==3.7
   - bcftools==1.9

--- a/snappy_wrappers/wrappers/gatk_ug_par/environment.yaml
+++ b/snappy_wrappers/wrappers/gatk_ug_par/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda
+  - nodefaults
 dependencies:
   - gatk_nonfree==3.7
   - bcftools==1.19

--- a/snappy_wrappers/wrappers/gcnv/environment.yaml
+++ b/snappy_wrappers/wrappers/gcnv/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - gatk4==4.3.0.0
   - bcftools==1.10.2

--- a/snappy_wrappers/wrappers/gcnv/merge_multikit_families/environment.yaml
+++ b/snappy_wrappers/wrappers/gcnv/merge_multikit_families/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - attrs==23.2.0
   - logzero==1.7.0

--- a/snappy_wrappers/wrappers/hera/quant/environment.yaml
+++ b/snappy_wrappers/wrappers/hera/quant/environment.yaml
@@ -1,5 +1,6 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- hera ==1.1
+  - hera ==1.1

--- a/snappy_wrappers/wrappers/hts_screen/environment.yaml
+++ b/snappy_wrappers/wrappers/hts_screen/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bwa==0.7.17
   - seqtk==1.4

--- a/snappy_wrappers/wrappers/jaffa/run/environment.yaml
+++ b/snappy_wrappers/wrappers/jaffa/run/environment.yaml
@@ -1,7 +1,8 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- jaffa==1.09
-- r-base==4.2.2
-- htslib==1.17
+  - jaffa==1.09
+  - r-base==4.2.2
+  - htslib==1.17

--- a/snappy_wrappers/wrappers/jannovar/environment.yaml
+++ b/snappy_wrappers/wrappers/jannovar/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.12
   - htslib==1.12

--- a/snappy_wrappers/wrappers/jannovar/statistics/environment.yaml
+++ b/snappy_wrappers/wrappers/jannovar/statistics/environment.yaml
@@ -1,6 +1,7 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- jannovar-cli ==0.33
-- htslib ==1.8
+  - jannovar-cli ==0.33
+  - htslib ==1.8

--- a/snappy_wrappers/wrappers/link_in_bam/environment.yaml
+++ b/snappy_wrappers/wrappers/link_in_bam/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - samtools ==1.19.2
   - gnuplot ==5.4.8

--- a/snappy_wrappers/wrappers/lohhla/environment.yaml
+++ b/snappy_wrappers/wrappers/lohhla/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - lohhla==20171108
   - kmer-jellyfish==2.3.1

--- a/snappy_wrappers/wrappers/maelstrom/environment.yaml
+++ b/snappy_wrappers/wrappers/maelstrom/environment.yaml
@@ -1,9 +1,10 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- bcftools ==1.12
-- samtools ==1.12
-- htslib ==1.12
-- ucsc-wigtobigwig ==377
-- maelstrom-core ==0.1.1
+  - bcftools ==1.12
+  - samtools ==1.12
+  - htslib ==1.12
+  - ucsc-wigtobigwig ==377
+  - maelstrom-core ==0.1.1

--- a/snappy_wrappers/wrappers/manta/germline_wgs/environment.yaml
+++ b/snappy_wrappers/wrappers/manta/germline_wgs/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - manta==1.6.0
   - samtools==1.9

--- a/snappy_wrappers/wrappers/manta/somatic_wgs/environment.yaml
+++ b/snappy_wrappers/wrappers/manta/somatic_wgs/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - manta==1.5.0

--- a/snappy_wrappers/wrappers/mantis/mantis_msi2/run/environment.yaml
+++ b/snappy_wrappers/wrappers/mantis/mantis_msi2/run/environment.yaml
@@ -1,5 +1,6 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- mantis-msi2
+  - mantis-msi2

--- a/snappy_wrappers/wrappers/mbcs/environment.yaml
+++ b/snappy_wrappers/wrappers/mbcs/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - cffi==1.16.0
   - pandas==2.2.1

--- a/snappy_wrappers/wrappers/mehari/environment.yaml
+++ b/snappy_wrappers/wrappers/mehari/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.19
   - htslib==1.19.1

--- a/snappy_wrappers/wrappers/melt/environment.yaml
+++ b/snappy_wrappers/wrappers/melt/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.16
   - bcftools==1.16

--- a/snappy_wrappers/wrappers/minialign/run/environment.yaml
+++ b/snappy_wrappers/wrappers/minialign/run/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda
+  - nodefaults
 dependencies:
   - minialign==0.5.3
   - samtools==1.9

--- a/snappy_wrappers/wrappers/minimap2/environment.yaml
+++ b/snappy_wrappers/wrappers/minimap2/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - minimap2==2.24
   - samtools==1.9

--- a/snappy_wrappers/wrappers/mutect/environment.yaml
+++ b/snappy_wrappers/wrappers/mutect/environment.yaml
@@ -2,6 +2,7 @@ channels:
   - conda-forge
   - bioconda
   - http://conda.cubi.bihealth.org/cubiconda
+  - nodefaults
 dependencies:
   - mutect_nonfree==1.1.7
   - htslib==1.19.1

--- a/snappy_wrappers/wrappers/mutect2/environment.yaml
+++ b/snappy_wrappers/wrappers/mutect2/environment.yaml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
   - bioconda
-
+  - nodefaults
 dependencies:
   - python=3.12
   - gatk4==4.3.0.0

--- a/snappy_wrappers/wrappers/ngs_chew/fingerprint/environment.yaml
+++ b/snappy_wrappers/wrappers/ngs_chew/fingerprint/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - ngs-chew==0.9.4

--- a/snappy_wrappers/wrappers/optitype/environment.yaml
+++ b/snappy_wrappers/wrappers/optitype/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - samtools==1.19.2
   - seqtk==1.3

--- a/snappy_wrappers/wrappers/peddy/run/environment.yaml
+++ b/snappy_wrappers/wrappers/peddy/run/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - peddy==0.4.8

--- a/snappy_wrappers/wrappers/picard/environment.yaml
+++ b/snappy_wrappers/wrappers/picard/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - picard==3.1.1
   - bedtools==2.31.1

--- a/snappy_wrappers/wrappers/pizzly/run/environment.yaml
+++ b/snappy_wrappers/wrappers/pizzly/run/environment.yaml
@@ -1,6 +1,7 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- pizzly ==0.37.3
-- kallisto ==0.43.1
+  - pizzly ==0.37.3
+  - kallisto ==0.43.1

--- a/snappy_wrappers/wrappers/platypus/call_joint/environment.yaml
+++ b/snappy_wrappers/wrappers/platypus/call_joint/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==2.7.15
   - platypus-variant==0.8.1.1

--- a/snappy_wrappers/wrappers/popdel/environment.yaml
+++ b/snappy_wrappers/wrappers/popdel/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - popdel==1.1.2
   - htslib==1.19.1

--- a/snappy_wrappers/wrappers/purecn/environment.yaml
+++ b/snappy_wrappers/wrappers/purecn/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.19.1

--- a/snappy_wrappers/wrappers/r/environment.yaml
+++ b/snappy_wrappers/wrappers/r/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==4.3.3
   - r-remotes==2.5.0

--- a/snappy_wrappers/wrappers/rnaqc/duplication/environment.yaml
+++ b/snappy_wrappers/wrappers/rnaqc/duplication/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - samtools==1.19.2
   - rseqc==5.0.3

--- a/snappy_wrappers/wrappers/rnaqc/dupradar/environment.yaml
+++ b/snappy_wrappers/wrappers/rnaqc/dupradar/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - samtools==1.12
   - r-base==4.0

--- a/snappy_wrappers/wrappers/rnaqc/environment.yaml
+++ b/snappy_wrappers/wrappers/rnaqc/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==4.0
   - bioconductor-dupradar==1.20.0

--- a/snappy_wrappers/wrappers/rnaqc/rnaseqc/environment.yaml
+++ b/snappy_wrappers/wrappers/rnaqc/rnaseqc/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - samtools==1.19.2
   - rna-seqc==1.1.8

--- a/snappy_wrappers/wrappers/rnaqc/stats/environment.yaml
+++ b/snappy_wrappers/wrappers/rnaqc/stats/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - samtools==1.19.2

--- a/snappy_wrappers/wrappers/rseqc/environment.yaml
+++ b/snappy_wrappers/wrappers/rseqc/environment.yaml
@@ -1,4 +1,6 @@
 channels:
+  - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - rseqc==5.0.3

--- a/snappy_wrappers/wrappers/salmon/environment.yaml
+++ b/snappy_wrappers/wrappers/salmon/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - salmon==1.10.3

--- a/snappy_wrappers/wrappers/samtools/bam_qc_report/environment.yaml
+++ b/snappy_wrappers/wrappers/samtools/bam_qc_report/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - samtools==1.9
   # NB: gnuplot 5.2.7 is incompatible with samtools ==1.9

--- a/snappy_wrappers/wrappers/scalpel/somatic/environment.yaml
+++ b/snappy_wrappers/wrappers/scalpel/somatic/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - scalpel==0.5.3
   - htslib==1.15.1

--- a/snappy_wrappers/wrappers/scarHRD/environment.yaml
+++ b/snappy_wrappers/wrappers/scarHRD/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==3.9.19
   - r-base==4.3.3

--- a/snappy_wrappers/wrappers/scramble/environment.yaml
+++ b/snappy_wrappers/wrappers/scramble/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - scramble==1.0.2
   - bcftools==1.15.1

--- a/snappy_wrappers/wrappers/sequenza/gcreference/environment.yaml
+++ b/snappy_wrappers/wrappers/sequenza/gcreference/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==3.9.19
   - sequenza-utils==3.0.0

--- a/snappy_wrappers/wrappers/sequenza/install/environment.yaml
+++ b/snappy_wrappers/wrappers/sequenza/install/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==3.9.19
   - r-base==4.3.3

--- a/snappy_wrappers/wrappers/signatures/deconstruct_sigs/environment.yaml
+++ b/snappy_wrappers/wrappers/signatures/deconstruct_sigs/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==4.3
   - r-tidyverse==2.0.0

--- a/snappy_wrappers/wrappers/signatures/tabulate_vcf/environment.yaml
+++ b/snappy_wrappers/wrappers/signatures/tabulate_vcf/environment.yaml
@@ -1,6 +1,7 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- bcftools ==1.3.1
+  - bcftools ==1.3.1
 

--- a/snappy_wrappers/wrappers/sniffles2/germline/environment.yaml
+++ b/snappy_wrappers/wrappers/sniffles2/germline/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - sniffles==2.2
   - htslib==1.16

--- a/snappy_wrappers/wrappers/somatic_cnv_checking/environment.yaml
+++ b/snappy_wrappers/wrappers/somatic_cnv_checking/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - r-base==4.3.3
   - r-dplyr==1.1.4

--- a/snappy_wrappers/wrappers/somatic_variant_filtration/apply_all_filters/environment.yaml
+++ b/snappy_wrappers/wrappers/somatic_variant_filtration/apply_all_filters/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.19.1
   - bcftools==1.19

--- a/snappy_wrappers/wrappers/somatic_variant_filtration/apply_filters/environment.yaml
+++ b/snappy_wrappers/wrappers/somatic_variant_filtration/apply_filters/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.19.1
   - bcftools==1.19

--- a/snappy_wrappers/wrappers/somatic_variant_filtration/filter_to_exons/environment.yaml
+++ b/snappy_wrappers/wrappers/somatic_variant_filtration/filter_to_exons/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.5
   - bedtools==2.26.0

--- a/snappy_wrappers/wrappers/star/environment.yaml
+++ b/snappy_wrappers/wrappers/star/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - star ==2.7.3a
   - samtools ==1.9

--- a/snappy_wrappers/wrappers/star_fusion/environment.yaml
+++ b/snappy_wrappers/wrappers/star_fusion/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - star-fusion==1.0.0
   - samtools==1.9

--- a/snappy_wrappers/wrappers/strelka2/environment.yaml
+++ b/snappy_wrappers/wrappers/strelka2/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - manta==1.6.0
   - strelka==2.9.10

--- a/snappy_wrappers/wrappers/svtk/environment.yaml
+++ b/snappy_wrappers/wrappers/svtk/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - svtk==0.0.20190615
   - bcftools==1.19

--- a/snappy_wrappers/wrappers/varfish_annotator/environment.yaml
+++ b/snappy_wrappers/wrappers/varfish_annotator/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.19
   - htslib==1.19.1

--- a/snappy_wrappers/wrappers/variant_filtration/collect_msdn/environment.yaml
+++ b/snappy_wrappers/wrappers/variant_filtration/collect_msdn/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.5

--- a/snappy_wrappers/wrappers/variant_filtration/environment.yaml
+++ b/snappy_wrappers/wrappers/variant_filtration/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.9
   - htslib==1.9

--- a/snappy_wrappers/wrappers/variant_filtration/filter_denovo/environment.yaml
+++ b/snappy_wrappers/wrappers/variant_filtration/filter_denovo/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.19.1

--- a/snappy_wrappers/wrappers/variant_filtration/filter_denovo_hard/environment.yaml
+++ b/snappy_wrappers/wrappers/variant_filtration/filter_denovo_hard/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==3.10.8
   - htslib==1.9

--- a/snappy_wrappers/wrappers/variant_filtration/summarize_counts/environment.yaml
+++ b/snappy_wrappers/wrappers/variant_filtration/summarize_counts/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - htslib==1.5

--- a/snappy_wrappers/wrappers/varscan/call_joint/environment.yaml
+++ b/snappy_wrappers/wrappers/varscan/call_joint/environment.yaml
@@ -1,9 +1,10 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- bcftools ==1.5
-- htslib ==1.5
-- samtools ==1.5
-- varscan ==2.4.2
-- parallel ==20170422
+  - bcftools ==1.5
+  - htslib ==1.5
+  - samtools ==1.5
+  - varscan ==2.4.2
+  - parallel ==20170422

--- a/snappy_wrappers/wrappers/varscan_par/call_joint/environment.yaml
+++ b/snappy_wrappers/wrappers/varscan_par/call_joint/environment.yaml
@@ -1,10 +1,11 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-- python =3.12
-- bcftools ==1.5
-- htslib ==1.5
-- parallel ==20170422
-- samtools ==1.5
-- varscan ==2.4.2
+  - python =3.12
+  - bcftools ==1.5
+  - htslib ==1.5
+  - parallel ==20170422
+  - samtools ==1.5
+  - varscan ==2.4.2

--- a/snappy_wrappers/wrappers/vcf2maf/vcf2maf/environment.yaml
+++ b/snappy_wrappers/wrappers/vcf2maf/vcf2maf/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - vcf2maf==1.6.18
   - ensembl-vep==100.4

--- a/snappy_wrappers/wrappers/vcf2maf/vcf_to_table/environment.yaml
+++ b/snappy_wrappers/wrappers/vcf2maf/vcf_to_table/environment.yaml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
   - bioconda
-
+  - nodefaults
 dependencies:
   - python==3.10.14
   - vcfpy==0.13.8

--- a/snappy_wrappers/wrappers/vcf_cnv_filter/environment.yaml
+++ b/snappy_wrappers/wrappers/vcf_cnv_filter/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==3.6.15
   - vcfpy==0.13.3

--- a/snappy_wrappers/wrappers/vcf_mei_filter/environment.yaml
+++ b/snappy_wrappers/wrappers/vcf_mei_filter/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - python==3.6.15
   - vcfpy==0.11.0

--- a/snappy_wrappers/wrappers/vcf_sv_filter/environment.yaml
+++ b/snappy_wrappers/wrappers/vcf_sv_filter/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - vcfpy==0.11.1
   - pytabix==0.0.2

--- a/snappy_wrappers/wrappers/vcfpy/add_bed/environment.yaml
+++ b/snappy_wrappers/wrappers/vcfpy/add_bed/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.19
   - vcfpy==0.13.8

--- a/snappy_wrappers/wrappers/vep/environment.yaml
+++ b/snappy_wrappers/wrappers/vep/environment.yaml
@@ -1,5 +1,6 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - ensembl-vep==109.3

--- a/snappy_wrappers/wrappers/vep/run/environment.yaml
+++ b/snappy_wrappers/wrappers/vep/run/environment.yaml
@@ -1,4 +1,6 @@
 channels:
+  - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - ensembl-vep==102.0

--- a/snappy_wrappers/wrappers/wgs_cnv_filtration/environment.yaml
+++ b/snappy_wrappers/wrappers/wgs_cnv_filtration/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.8
   - htslib==1.8

--- a/snappy_wrappers/wrappers/wgs_cnv_filtration/filter_inheritance/environment.yaml
+++ b/snappy_wrappers/wrappers/wgs_cnv_filtration/filter_inheritance/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.8
   - htslib==1.8

--- a/snappy_wrappers/wrappers/wgs_cnv_filtration/filter_quality/environment.yaml
+++ b/snappy_wrappers/wrappers/wgs_cnv_filtration/filter_quality/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.8
   - htslib==1.8

--- a/snappy_wrappers/wrappers/wgs_cnv_filtration/filter_regions/environment.yaml
+++ b/snappy_wrappers/wrappers/wgs_cnv_filtration/filter_regions/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.8
   - htslib==1.8

--- a/snappy_wrappers/wrappers/wgs_sv_filtration/environment.yaml
+++ b/snappy_wrappers/wrappers/wgs_sv_filtration/environment.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
   - bioconda
+  - nodefaults
 dependencies:
   - bcftools==1.8
   - htslib==1.8


### PR DESCRIPTION
In order to avoid accidentally pulling in packages from anaconda's default channel, explicitly add `nodefaults` to channels.