### PR TITLE
feat: Update GCNV environment to 0.9 kernel and GATK4.6.1

### DIFF
--- a/snappy_wrappers/wrappers/gcnv/call_cnvs_case_mode/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/call_cnvs_case_mode/wrapper.py
@@ -17,6 +17,7 @@ trap "rm -rf $TMPDIR" ERR EXIT
 export MKL_NUM_THREADS=16
 export OMP_NUM_THREADS=16
 export THEANO_FLAGS="base_compiledir=$TMPDIR/theano_compile_dir"
+export PYTENSOR_FLAGS="base_compiledir=$TMPDIR/pytensor_compile_dir"
 
 # Force full replacement of previous results
 # (this also solves issues when gatk tries to shutil copy file ownership)

--- a/snappy_wrappers/wrappers/gcnv/call_cnvs_cohort_mode/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/call_cnvs_cohort_mode/wrapper.py
@@ -21,6 +21,7 @@ trap "rm -rf $TMPDIR" ERR EXIT
 export MKL_NUM_THREADS=16
 export OMP_NUM_THREADS=16
 export THEANO_FLAGS="base_compiledir=$TMPDIR/theano_compile_dir"
+export PYTENSOR_FLAGS="base_compiledir=$TMPDIR/pytensor_compile_dir"
 
 gatk GermlineCNVCaller \
     --run-mode COHORT \

--- a/snappy_wrappers/wrappers/gcnv/contig_ploidy/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/contig_ploidy/wrapper.py
@@ -42,6 +42,7 @@ trap "rm -rf $TMPDIR" ERR EXIT
 export MKL_NUM_THREADS={snakemake.threads}
 export OMP_NUM_THREADS={snakemake.threads}
 export THEANO_FLAGS="base_compiledir=$TMPDIR/theano_compile_dir"
+export PYTENSOR_FLAGS="base_compiledir=$TMPDIR/pytensor_compile_dir"
 
 # Get contig name style
 egrep "^@SQ\s+SN:chr[0-9XY]{{1,2}}\s+" {snakemake.input.interval_list} > /dev/null && true

--- a/snappy_wrappers/wrappers/gcnv/contig_ploidy_case_mode/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/contig_ploidy_case_mode/wrapper.py
@@ -36,6 +36,7 @@ paths_tsv = " ".join(snakemake.input.tsv)
 shell(
     r"""
 export THEANO_FLAGS="base_compiledir=$TMPDIR/theano_compile_dir"
+export PYTENSOR_FLAGS="base_compiledir=$TMPDIR/pytensor_compile_dir"
 
 set -x
 

--- a/snappy_wrappers/wrappers/gcnv/environment.yaml
+++ b/snappy_wrappers/wrappers/gcnv/environment.yaml
@@ -3,40 +3,8 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - gatk4==4.3.0.0
-  - bcftools==1.10.2
-  - htslib==1.10.2
+  - gatk4==4.6.1.0
+  - bcftools
+  - htslib
   - parallel==20240122
-  # the hard to install gcnvkernel
-  - gcnvkernel==0.8
-  # gcnvkernel dependencies
-  - python==3.6.10
-  - pip==21.3.1
-  - mkl==2019.5
-  - mkl-service==2.3.0
-  - numpy==1.17.5
-  - theano==1.0.4
-  - tensorflow==1.10.0
-  - scipy==1.0.0
-  - pymc3==3.1
-  - joblib==1.2.0
-  - h5py==2.10.0
-  - keras==2.2.4
-  - intel-openmp==2022.1.0
-  - scikit-learn==0.23.1
-  - matplotlib==3.2.1
-  - pandas==1.0.3
-  - typing_extensions==4.1.1
-  - dill==0.3.4
-  - r-base==3.6.2
-  - r-data.table==1.12.8
-  - r-dplyr==0.8.5
-  - r-getopt==1.20.3
-  - r-ggplot2==3.3.0
-  - r-gplots==3.0.3
-  - r-gsalib==2.1
-  - r-optparse==1.6.4
-  - r-backports==1.1.10
-  - biopython==1.76
-  - pyvcf==0.6.8
-  - pysam==0.15.3
+  - gcnvkernel==0.9

--- a/snappy_wrappers/wrappers/gcnv/post_germline_calls/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/post_germline_calls/wrapper.py
@@ -13,6 +13,7 @@ export TMPDIR=$(mktemp -d)
 trap "rm -rf $TMPDIR" ERR EXIT
 
 export THEANO_FLAGS="base_compiledir=$TMPDIR/theano_compile_dir"
+export PYTENSOR_FLAGS="base_compiledir=$TMPDIR/pytensor_compile_dir"
 
 itv_vcf={snakemake.output.itv_vcf}
 seg_vcf={snakemake.output.seg_vcf}

--- a/snappy_wrappers/wrappers/gcnv/post_germline_calls_case_mode/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/post_germline_calls_case_mode/wrapper.py
@@ -13,6 +13,7 @@ export TMPDIR=$(mktemp -d)
 trap "rm -rf $TMPDIR" ERR EXIT
 
 export THEANO_FLAGS="base_compiledir=$TMPDIR/theano_compile_dir"
+export PYTENSOR_FLAGS="base_compiledir=$TMPDIR/pytensor_compile_dir"
 
 itv_vcf={snakemake.output.itv_vcf}
 seg_vcf={snakemake.output.seg_vcf}

--- a/snappy_wrappers/wrappers/gcnv/preprocess_intervals/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/preprocess_intervals/wrapper.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # isort:skip_file
-from snappy_pipeline.utils import DictQuery
-import os
+#from snappy_pipeline.utils import DictQuery
+#import os
 
 from snakemake.shell import shell
 

--- a/snappy_wrappers/wrappers/gcnv/preprocess_intervals/wrapper.py
+++ b/snappy_wrappers/wrappers/gcnv/preprocess_intervals/wrapper.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # isort:skip_file
-#from snappy_pipeline.utils import DictQuery
-#import os
 
 from snakemake.shell import shell
 


### PR DESCRIPTION
gcnvkernel 0.8 is not installable from conda-forge (only), since some dependencies are only available from anaconda.
We therefore update to gcnvkernel 0.9, which has updated its dependencies, and use the opportunity to update GATK to version 4.6 as well.