### PR TITLE
fix: allow bwa_mem2 and mbcs in cbioportal_export model

### DIFF
--- a/snappy_pipeline/workflows/cbioportal_export/model.py
+++ b/snappy_pipeline/workflows/cbioportal_export/model.py
@@ -10,6 +10,8 @@ from snappy_pipeline.models import SnappyModel, SnappyStepModel
 
 class MappingTool(enum.StrEnum):
     BWA = "bwa"
+    BWA_MEM2 = "bwa_mem2"
+    MBCS = "mbcs"
 
 
 class ExpressionTool(enum.StrEnum):


### PR DESCRIPTION
Fixes #600 