### PR TITLE
refactor: cbioportal export model is unclear about use of filtration

### DIFF
--- a/snappy_pipeline/workflows/cbioportal_export/__init__.py
+++ b/snappy_pipeline/workflows/cbioportal_export/__init__.py
@@ -18,6 +18,7 @@ from snappy_pipeline.utils import dictify, listify
 from snappy_pipeline.workflows.abstract import BaseStep, BaseStepPart, ResourceUsage
 
 from .model import CbioportalExport as CbioportalExportConfigModel
+from .model import FiltrationSchema
 
 # cbioportal meta data files
 META_FILES = {
@@ -296,17 +297,13 @@ class cbioportalMutationsStepPart(cbioportalExportStepPart):
 
     def __init__(self, parent):
         super().__init__(parent)
-        if self.config.filter_set:
-            if self.config.filter_set == "filter_list":
-                name_pattern = "{mapper}.{caller}.{annotator}.filtered.{{library_name}}"
-            else:
-                name_pattern = (
-                    "{mapper}.{caller}.{annotator}."
-                    "dkfz_bias_filter.eb_filter.{{library_name}}."
-                    "{filter_set}.{exon_list}"
-                )
+        name_pattern = "{mapper}.{caller}.{annotator}."
+        if self.config.filtration_schema == FiltrationSchema.list:
+            name_pattern += "filtered.{{library_name}}"
+        elif self.config.filtration_schema == FiltrationSchema.sets:
+            name_pattern += "dkfz_bias_filter.eb_filter.{{library_name}}.{filter_set}.{exon_list}"
         else:
-            name_pattern = "{mapper}.{caller}.{annotator}.{{library_name}}"
+            name_pattern += "{{library_name}}"
         tpl = os.path.join("work/maf", name_pattern, "out", name_pattern + "{ext}")
         self.input_tpl = tpl.format(
             mapper=self.config.mapping_tool,
@@ -741,15 +738,18 @@ class cbioportalExportWorkflow(BaseStep):
         )
         # Initialize sub-workflows
         if self.config.path_somatic_variant:
-            if self.config.filter_set:
+            if (
+                self.config.filtration_schema == FiltrationSchema.unfiltered
+                or self.config.filter_before_annotation
+            ):
                 self.register_sub_workflow(
-                    "somatic_variant_filtration",
+                    "somatic_variant_annotation",
                     self.config.path_somatic_variant,
                     sub_workflow_name="somatic_variant",
                 )
             else:
                 self.register_sub_workflow(
-                    "somatic_variant_annotation",
+                    "somatic_variant_filtration",
                     self.config.path_somatic_variant,
                     sub_workflow_name="somatic_variant",
                 )

--- a/snappy_pipeline/workflows/cbioportal_export/model.py
+++ b/snappy_pipeline/workflows/cbioportal_export/model.py
@@ -27,6 +27,12 @@ class SomaticVariantAnnotationTool(enum.StrEnum):
     VEP = "vep"
 
 
+class FiltrationSchema(enum.StrEnum):
+    unfiltered = "unfiltered"
+    list = "list"
+    sets = "sets"
+
+
 class FilterSet(enum.StrEnum):
     NO_FILTER = "no_filter"
     DKFZ_ONLY = "dkfz_only"
@@ -132,6 +138,12 @@ class CbioportalExport(SnappyStepModel):
 
     somatic_variant_annotation_tool: SomaticVariantAnnotationTool = SomaticVariantAnnotationTool.VEP
 
+    filtration_schema: FiltrationSchema = FiltrationSchema.list
+    """Method of variant filtration (if any)"""
+
+    filter_before_annotation: bool = False
+    """Flag if filtration has been done before annotation"""
+
     filter_set: Annotated[FilterSet | None, Field(None, deprecated="use `filter_list` instead")]
     """
     DEPRECATED: use `filter_list instead`.
@@ -149,8 +161,6 @@ class CbioportalExport(SnappyStepModel):
     DEPRECATED.
     Works together with filter_set, ignored when "filter_list" is selected
     """
-
-    filter_list: list[Filter] = []
 
     exclude_variant_with_flag: str | None = None
     """Required for Copy Number Alterations"""

--- a/snappy_pipeline/workflows/somatic_variant_annotation/__init__.py
+++ b/snappy_pipeline/workflows/somatic_variant_annotation/__init__.py
@@ -90,6 +90,7 @@ from snappy_pipeline.workflows.somatic_variant_calling import (
 )
 
 from .model import SomaticVariantAnnotation as SomaticVariantAnnotationConfigModel
+from .model import FiltrationSchema
 
 __author__ = "Manuel Holtgrewe <manuel.holtgrewe@bih-charite.de>"
 
@@ -136,11 +137,21 @@ class AnnotateSomaticVcfStepPart(BaseStepPart):
         """Return path to somatic vcf input file"""
         # Validate action
         self._validate_action(action)
-        tpl = (
-            "output/{mapper}.{var_caller}.{tumor_library}/out/{mapper}.{var_caller}.{tumor_library}"
-        )
+        tpl = "{mapper}.{var_caller}"
+        if self.config.filtration_schema == FiltrationSchema.list:
+            tpl += ".filtered.{tumor_library}"
+        elif self.config.filtration_schema == FiltrationSchema.sets:
+            tpl += ".".join(
+                "dkfz_bias_filter.eb_filter",
+                "{tumor_library}",
+                self.config.filter_sets,
+                self.config.exon_lists,
+            )
+        elif self.config.filtration_schema == FiltrationSchema.unfiltered:
+            tpl += ".{tumor_library}"
+        tpl = os.path.join("output", tpl, "out", tpl)
         key_ext = {"vcf": ".vcf.gz", "vcf_tbi": ".vcf.gz.tbi"}
-        variant_calling = self.parent.sub_workflows["somatic_variant_calling"]
+        variant_calling = self.parent.sub_workflows["somatic_variant"]
         for key, ext in key_ext.items():
             yield key, variant_calling(tpl + ext)
 
@@ -149,10 +160,19 @@ class AnnotateSomaticVcfStepPart(BaseStepPart):
         """Return output files for the filtration"""
         # Validate action
         self._validate_action(action)
-        prefix = (
-            "work/{{mapper}}.{{var_caller}}.{annotator}.{{tumor_library}}/out/"
-            "{{mapper}}.{{var_caller}}.{annotator}.{{tumor_library}}"
-        ).format(annotator=self.annotator)
+        tpl = f"{{mapper}}.{{var_caller}}.{self.annotator}"
+        if self.config.filtration_schema == FiltrationSchema.list:
+            tpl += ".filtered.{tumor_library}"
+        elif self.config.filtration_schema == FiltrationSchema.sets:
+            tpl += ".".join(
+                "dkfz_bias_filter.eb_filter",
+                "{tumor_library}",
+                self.config.filter_sets,
+                self.config.exon_lists,
+            )
+        elif self.config.filtration_schema == FiltrationSchema.unfiltered:
+            tpl += ".{tumor_library}"
+        prefix = os.path.join("work", tpl, "out", tpl)
         key_ext = {"vcf": ".vcf.gz", "vcf_tbi": ".vcf.gz.tbi"}
         if self.has_full:
             key_ext["full"] = ".full.vcf.gz"
@@ -166,10 +186,19 @@ class AnnotateSomaticVcfStepPart(BaseStepPart):
         """Return mapping of log files."""
         # Validate action
         self._validate_action(action)
-        prefix = (
-            "work/{{mapper}}.{{var_caller}}.{annotator}.{{tumor_library}}/log/"
-            "{{mapper}}.{{var_caller}}.{annotator}.{{tumor_library}}"
-        ).format(annotator=self.annotator)
+        tpl = f"{{mapper}}.{{var_caller}}.{self.annotator}"
+        if self.config.filtration_schema == FiltrationSchema.list:
+            tpl += ".filtered.{tumor_library}"
+        elif self.config.filtration_schema == FiltrationSchema.sets:
+            tpl += ".".join(
+                "dkfz_bias_filter.eb_filter",
+                "{tumor_library}",
+                self.config.filter_sets,
+                self.config.exon_lists,
+            )
+        elif self.config.filtration_schema == FiltrationSchema.unfiltered:
+            tpl += ".{tumor_library}"
+        prefix = os.path.join("work", tpl, "log", tpl)
 
         key_ext = (
             ("log", ".log"),
@@ -289,6 +318,26 @@ class SomaticVariantAnnotationWorkflow(BaseStep):
         return DEFAULT_CONFIG
 
     def __init__(self, workflow, config, config_lookup_paths, config_paths, workdir):
+        # Ugly hack to allow exchanging the order of somatic_variant_annotation &
+        # somatic_variant_filtration steps.
+        # The import of the other workflow must be dependent on the config:
+        # if in the somatic_variant_annotation config, the filtration_schema is not unfiltered,
+        # then the annotation step will include the filtration workflow as a
+        # previous step.
+        # THIS IMPLIES THAT NO ANNOTATION OCCURED BEFORE FILTRATION
+        # This protects against circular import of workflows.
+        #
+        # This must be done before initialisation of the workflow.
+        default = str(SomaticVariantAnnotationConfigModel.model_fields["filtration_schema"].default)
+        previous_steps = [SomaticVariantCallingWorkflow, NgsMappingWorkflow]
+        if config["step_config"]["somatic_variant_annotation"].get(
+            "filtration_schema", default
+        ) != str(FiltrationSchema.unfiltered):
+            from snappy_pipeline.workflows.somatic_variant_filtration import (
+                SomaticVariantFiltrationWorkflow,
+            )
+
+            previous_steps.insert(0, SomaticVariantFiltrationWorkflow)
         super().__init__(
             workflow,
             config,
@@ -296,16 +345,21 @@ class SomaticVariantAnnotationWorkflow(BaseStep):
             config_paths,
             workdir,
             config_model_class=SomaticVariantAnnotationConfigModel,
-            previous_steps=(SomaticVariantCallingWorkflow, NgsMappingWorkflow),
+            previous_steps=previous_steps,
         )
         # Register sub step classes so the sub steps are available
         self.register_sub_step_classes(
             (JannovarAnnotateSomaticVcfStepPart, VepAnnotateSomaticVcfStepPart, LinkOutStepPart)
         )
         # Register sub workflows
-        self.register_sub_workflow(
-            "somatic_variant_calling", self.config.path_somatic_variant_calling
-        )
+        if self.config.filtration_schema == FiltrationSchema.unfiltered:
+            self.register_sub_workflow(
+                "somatic_variant_calling", self.config.path_somatic_variant, "somatic_variant"
+            )
+        else:
+            self.register_sub_workflow(
+                "somatic_variant_filtration", self.config.path_somatic_variant, "somatic_variant"
+            )
         # Copy over "tools" setting from somatic_variant_calling/ngs_mapping if not set here
         if not self.config.tools_ngs_mapping:
             self.config.tools_ngs_mapping = self.w_config.step_config["ngs_mapping"].tools.dna
@@ -322,7 +376,18 @@ class SomaticVariantAnnotationWorkflow(BaseStep):
         """
         annotators = set(self.config.tools) & set(ANNOTATION_TOOLS)
         callers = set(self.config.tools_somatic_variant_calling)
-        name_pattern = "{mapper}.{caller}.{annotator}.{tumor_library.name}"
+        name_pattern = "{mapper}.{caller}.{annotator}"
+        if self.config.filtration_schema == FiltrationSchema.list:
+            name_pattern += ".filtered.{tumor_library.name}"
+        elif self.config.filtration_schema == FiltrationSchema.sets:
+            name_pattern += ".".join(
+                "dkfz_bias_filter.eb_filter",
+                "{tumor_library.name}",
+                self.config.filter_sets,
+                self.config.exon_lists,
+            )
+        elif self.config.filtration_schema == FiltrationSchema.unfiltered:
+            name_pattern += ".{tumor_library.name}"
         yield from self._yield_result_files_matched(
             os.path.join("output", name_pattern, "out", name_pattern + "{ext}"),
             mapper=self.config.tools_ngs_mapping,
@@ -359,7 +424,18 @@ class SomaticVariantAnnotationWorkflow(BaseStep):
             ext=EXT_VALUES,
         )
         # joint calling
-        name_pattern = "{mapper}.{caller}.{annotator}.{donor.name}"
+        name_pattern = "{mapper}.{caller}.{annotator}"
+        if self.config.filtration_schema == FiltrationSchema.list:
+            name_pattern += ".filtered.{donor.name}"
+        elif self.config.filtration_schema == FiltrationSchema.sets:
+            name_pattern += ".".join(
+                "dkfz_bias_filter.eb_filter",
+                "{donor.name}",
+                self.config.filter_sets,
+                self.config.exon_lists,
+            )
+        elif self.config.filtration_schema == FiltrationSchema.unfiltered:
+            name_pattern += ".{donor.name}"
         yield from self._yield_result_files_joint(
             os.path.join("output", name_pattern, "out", name_pattern + "{ext}"),
             mapper=self.w_config.step_config["ngs_mapping"].tools.dna,

--- a/snappy_pipeline/workflows/somatic_variant_annotation/model.py
+++ b/snappy_pipeline/workflows/somatic_variant_annotation/model.py
@@ -1,7 +1,7 @@
 import enum
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from snappy_pipeline.models import EnumField, SnappyModel, SnappyStepModel, validators
 from snappy_pipeline.models.annotation import Vep
@@ -55,10 +55,30 @@ class Jannovar(SnappyModel):
     """patterns of chromosome names to ignore"""
 
 
+class FiltrationSchema(enum.StrEnum):
+    unfiltered = "unfiltered"
+    list = "list"
+    sets = "sets"
+
+
+class FilterSets(enum.StrEnum):
+    NO_FILTER = "no_filter"
+    DKFZ_ONLY = "dkfz_only"
+    DKFZ_AND_EBFILTER = "dkfz_and_ebfilter"
+    DKFZ_AND_EBFILTER_AND_OXOG = "dkfz_and_ebfilter_and_oxog"
+
+
 class SomaticVariantAnnotation(SnappyStepModel, validators.ToolsMixin):
     tools: Annotated[list[Tool], EnumField(Tool, [Tool.jannovar, Tool.vep], min_length=1)]
 
-    path_somatic_variant_calling: Annotated[str, Field(examples=["../somatic_variant_calling"])]
+    path_somatic_variant: Annotated[str, Field(examples=["../somatic_variant_calling"])]
+
+    filtration_schema: FiltrationSchema = FiltrationSchema.unfiltered
+    """Method of variant filtration (if any)"""
+
+    filter_sets: Annotated[FilterSets | None, Field(deprecated="use filter_list instead")] = None
+
+    exon_lists: Annotated[str, Field(deprecated="use filter_list instead")] | None = None
 
     tools_ngs_mapping: list[str] = []
     """default to those configured for ngs_mapping"""
@@ -69,3 +89,12 @@ class SomaticVariantAnnotation(SnappyStepModel, validators.ToolsMixin):
     jannovar: Jannovar | None = None
 
     vep: Vep | None = None
+
+    @model_validator(mode="after")
+    def ensure_filter_sets_properly_configured(self):
+        if self.filtration_schema == FiltrationSchema.sets:
+            if not self.filter_sets:
+                raise ValueError(
+                    "filter_sets and exon_lists must be set (set exon_lists to 'genome_wide' if no exon list is provided)"
+                )
+        return self

--- a/snappy_pipeline/workflows/somatic_variant_filtration/__init__.py
+++ b/snappy_pipeline/workflows/somatic_variant_filtration/__init__.py
@@ -127,16 +127,14 @@ from snappy_pipeline.workflows.abstract import (
     ResourceUsage,
 )
 from snappy_pipeline.workflows.ngs_mapping import NgsMappingWorkflow
-from snappy_pipeline.workflows.somatic_variant_annotation import (
-    ANNOTATION_TOOLS,
-    SomaticVariantAnnotationWorkflow,
-)
 from snappy_pipeline.workflows.somatic_variant_calling import (
     SOMATIC_VARIANT_CALLERS_MATCHED,
     SomaticVariantCallingWorkflow,
 )
 
 from .model import SomaticVariantFiltration as SomaticVariantFiltrationConfigModel
+
+from snappy_pipeline.workflows.somatic_variant_annotation import ANNOTATION_TOOLS
 
 __author__ = "Manuel Holtgrewe <manuel.holtgrewe@bih-charite.de>"
 
@@ -948,6 +946,24 @@ class SomaticVariantFiltrationWorkflow(BaseStep):
         return DEFAULT_CONFIG
 
     def __init__(self, workflow, config, config_lookup_paths, config_paths, workdir):
+        # Ugly hack to allow exchanging the order of somatic_variant_annotation &
+        # somatic_variant_filtration steps.
+        # The import of the other workflow must be dependent on the config:
+        # if in the somatic_variant_filtration config, has_annotation is True,
+        # then the filtration step will include the annotation workflow as a
+        # previous step.
+        # THIS IMPLIES THAT NO FILTRATION OCCURED BEFORE ANNOTATION
+        # This protects against circular import of workflows.
+        #
+        # This must be done before initialisation of the workflow.
+        previous_steps = [SomaticVariantCallingWorkflow, NgsMappingWorkflow]
+        default = SomaticVariantFiltrationConfigModel.model_fields["has_annotation"].default
+        if config["step_config"]["somatic_variant_filtration"].get("has_annotation", default):
+            from snappy_pipeline.workflows.somatic_variant_annotation import (
+                SomaticVariantAnnotationWorkflow,
+            )
+
+            previous_steps.insert(0, SomaticVariantAnnotationWorkflow)
         super().__init__(
             workflow,
             config,
@@ -955,11 +971,7 @@ class SomaticVariantFiltrationWorkflow(BaseStep):
             config_paths,
             workdir,
             config_model_class=SomaticVariantFiltrationConfigModel,
-            previous_steps=(
-                SomaticVariantAnnotationWorkflow,
-                SomaticVariantCallingWorkflow,
-                NgsMappingWorkflow,
-            ),
+            previous_steps=previous_steps,
         )
         # Register sub step classes so the sub steps are available
         self.register_sub_step_classes(

--- a/snappy_pipeline/workflows/somatic_variant_signatures/__init__.py
+++ b/snappy_pipeline/workflows/somatic_variant_signatures/__init__.py
@@ -19,16 +19,15 @@ from snappy_pipeline.utils import dictify, listify
 from snappy_pipeline.workflows.abstract import BaseStep, BaseStepPart, LinkOutStepPart
 from snappy_pipeline.workflows.ngs_mapping import NgsMappingWorkflow, ResourceUsage
 from snappy_pipeline.workflows.somatic_variant_annotation import (
-    ANNOTATION_TOOLS,
     SomaticVariantAnnotationWorkflow,
 )
 from snappy_pipeline.workflows.somatic_variant_calling import (
-    SOMATIC_VARIANT_CALLERS_MATCHED,
     SomaticVariantCallingWorkflow,
 )
 from snappy_pipeline.workflows.somatic_variant_filtration import SomaticVariantFiltrationWorkflow
 
 from .model import SomaticVariantSignatures as SomaticVariantSignaturesConfigModel
+from .model import FiltrationSchema
 
 __author__ = "Clemens Messerschmidt"
 
@@ -44,16 +43,17 @@ class SignaturesStepPart(BaseStepPart):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.config = parent.w_config.step_config["somatic_variant_signatures"]
-        self.name_pattern = "{mapper}.{var_caller}"
-        if self.config.is_filtered:
-            if len(self.config.filters) == 0:
-                self.name_pattern += ".{anno_caller}.filtered"
-            else:
-                self.name_pattern += ".{anno_caller}.dkfz_bias_filter.eb_filter"
-        self.name_pattern += "." + self.name + ".{tumor_library}"
-        if self.config.is_filtered and len(self.config.filters) > 0:
-            self.name_pattern += ".{filter}.{region}"
+
+        self.name_prefix = "{mapper}.{var_caller}"
+        self.name_postfix = "{tumor_library}"
+        if self.config.has_annotation:
+            self.name_prefix += ".{anno_caller}"
+        if self.config.filtration_schema == FiltrationSchema.list:
+            self.name_prefix += ".filtered"
+        elif self.config.filtration_schema == FiltrationSchema.sets:
+            self.name_prefix += ".dkfz_bias_filter.eb_filter"
+            self.name_postfix += ".{filter}.{region}"
+
         # Build shortcut from cancer bio sample name to matched cancre sample
         self.tumor_ngs_library_to_sample_pair = OrderedDict()
         for sheet in self.parent.shortcut_sheets:
@@ -69,7 +69,8 @@ class SignaturesStepPart(BaseStepPart):
     def get_log_file(self, action):
         # Validate action
         self._validate_action(action)
-        return os.path.join("work", self.name_pattern, "log", "snakemake." + self.name + ".log")
+        name_pattern = self.name_prefix + f".{self.name}." + self.name_postfix
+        return os.path.join("work", name_pattern, "log", name_pattern + ".log")
 
     def get_resource_usage(self, action: str, **kwargs) -> ResourceUsage:
         """Get Resource Usage
@@ -99,15 +100,7 @@ class TabulateVariantsStepPart(SignaturesStepPart):
         """Return path to input file"""
         # Validate action
         self._validate_action(action)
-        name_pattern = "{mapper}.{var_caller}"
-        if self.config.is_filtered:
-            if len(self.config.filters) == 0:
-                name_pattern += ".{anno_caller}.filtered"
-            else:
-                name_pattern += ".{anno_caller}.dkfz_bias_filter.eb_filter"
-        name_pattern += ".{tumor_library}"
-        if self.config.is_filtered and len(self.config.filters) > 0:
-            name_pattern += ".{filter}.{region}"
+        name_pattern = self.name_prefix + "." + self.name_postfix
         tpl = os.path.join("output", name_pattern, "out", name_pattern)
         key_ext = {"vcf": ".vcf.gz", "vcf_tbi": ".vcf.gz.tbi"}
         variant_calling = self.parent.sub_workflows["somatic_variant"]
@@ -119,7 +112,8 @@ class TabulateVariantsStepPart(SignaturesStepPart):
         """Return output files to tabulate vcf"""
         # Validate action
         self._validate_action(action)
-        yield "tsv", os.path.join("work", self.name_pattern, "out", self.name_pattern + ".tsv")
+        name_pattern = self.name_prefix + ".tabulate_vcf." + self.name_postfix
+        yield "tsv", os.path.join("work", name_pattern, "out", name_pattern + ".tsv")
 
     def get_params(self, action):
         """Return arguments to pass down."""
@@ -157,15 +151,7 @@ class DeconstructSigsStepPart(SignaturesStepPart):
         """Return input files to deconstruct signatures"""
         # Validate action
         self._validate_action(action)
-        name_pattern = "{mapper}.{var_caller}"
-        if self.config.is_filtered:
-            if len(self.config.filters) == 0:
-                name_pattern += ".{anno_caller}.filtered"
-            else:
-                name_pattern += ".{anno_caller}.dkfz_bias_filter.eb_filter"
-        name_pattern += ".tabulate_vcf.{tumor_library}"
-        if self.config.is_filtered and len(self.config.filters) > 0:
-            name_pattern += ".{filter}.{region}"
+        name_pattern = self.name_prefix + ".tabulate_vcf." + self.name_postfix
         yield "tsv", os.path.join("work", name_pattern, "out", name_pattern + ".tsv")
 
     @dictify
@@ -173,8 +159,9 @@ class DeconstructSigsStepPart(SignaturesStepPart):
         """Return output files to deconstruct signatures"""
         # Validate action
         self._validate_action(action)
-        yield "tsv", os.path.join("work", self.name_pattern, "out", self.name_pattern + ".tsv")
-        yield "pdf", os.path.join("work", self.name_pattern, "out", self.name_pattern + ".pdf")
+        name_pattern = self.name_prefix + ".deconstruct_sigs." + self.name_postfix
+        yield "tsv", os.path.join("work", name_pattern, "out", name_pattern + ".tsv")
+        yield "pdf", os.path.join("work", name_pattern, "out", name_pattern + ".pdf")
 
 
 class SomaticVariantSignaturesWorkflow(BaseStep):
@@ -211,38 +198,64 @@ class SomaticVariantSignaturesWorkflow(BaseStep):
             ),
         )
         # Register sub workflows
-        config = self.w_config.step_config["somatic_variant_signatures"]
+        config = self.config
         sub_workflow = "somatic_variant_calling"
-        if config.is_filtered:
-            sub_workflow = "somatic_variant_filtration"
+        if config.filtration_schema == FiltrationSchema.unfiltered:
+            if config.has_annotation:
+                sub_workflow = "somatic_variant_annotation"
+        else:
+            if config.has_annotation and config.filter_before_annotation:
+                sub_workflow = "somatic_variant_annotation"
+            else:
+                sub_workflow = "somatic_variant_filtration"
         self.register_sub_workflow(sub_workflow, config.path_somatic_variant, "somatic_variant")
         # Copy over "tools" setting from somatic_variant_calling/ngs_mapping if not set here
+
+        tools = set(self.w_config.step_config["ngs_mapping"].tools.dna)
         if not config.tools_ngs_mapping:
-            config.tools_ngs_mapping = self.w_config.step_config["ngs_mapping"].tools.dna
+            config.tools_ngs_mapping = tools
+        else:
+            config.tools_ngs_mapping = set(config.tools_ngs_mapping) & tools
+        assert len(config.tools_ngs_mapping) > 0, "No valid ngs mapping tool"
+
+        tools = set(self.w_config.step_config["somatic_variant_calling"].tools)
         if not config.tools_somatic_variant_calling:
-            config.tools_somatic_variant_calling = self.w_config.step_config[
-                "somatic_variant_calling"
-            ].tools
-        if not config.tools_somatic_variant_annotation:
-            config.tools_somatic_variant_annotation = self.w_config.step_config[
-                "somatic_variant_annotation"
-            ].tools
-        if config.is_filtered:
-            if len(self.w_config.step_config["somatic_variant_filtration"].filter_list) > 0:
-                config.filters = []
-                config.filtered_regions = []
-            else:
-                if not config.filters:
-                    config.filters = list(
-                        self.w_config.step_config["somatic_variant_filtration"].filter_sets.keys()
-                    )
-                    config.filters.append("no_filter")
-                if not config.filtered_regions:
-                    config.filtered_regions = list(
-                        self.w_config.step_config["somatic_variant_filtration"].exon_lists.keys()
-                    )
-                    config.filtered_regions.append("genome_wide")
-        self.w_config.step_config["somatic_variant_signatures"] = config
+            config.tools_somatic_variant_calling = tools
+        else:
+            config.tools_somatic_variant_calling = set(config.tools_somatic_variant_calling) & tools
+        assert len(config.tools_somatic_variant_calling) > 0, (
+            "No valid somatic variant calling tool"
+        )
+
+        if config.has_annotation:
+            tools = set(self.w_config.step_config["somatic_variant_annotation"].tools)
+            if not config.tools_somatic_variant_annotation:
+                config.tools_somatic_variant_annotation = tools
+            config.tools_somatic_variant_annotation = (
+                set(config.tools_somatic_variant_annotation) & tools
+            )
+            assert len(config.tools_somatic_variant_annotation) > 0, (
+                "No valid somatic variant annotation tool"
+            )
+
+        if config.filtration_schema == FiltrationSchema.sets:
+            tools = set(
+                self.w_config.step_config["somatic_variant_filtration"].filter_sets.keys()
+            ) | set(["no_filter"])
+            if not config.filter_sets:
+                config.filter_sets = tools
+            config.filter_sets = set(config.filter_sets) & tools
+            assert len(config.filter_sets) > 0, "No valid filtration sets has been configured"
+            tools = set(
+                self.w_config.step_config["somatic_variant_filtration"].exon_lists.keys()
+            ) | set(["genome_wide"])
+            if not config.exon_lists:
+                config.exon_lists = tools
+            config.exon_lists = set(config.exon_lists) & tools
+            assert len(config.exon_lists) > 0, "No valid regions for filtration has been configured"
+
+        self.config = config
+
         # Register sub step classes so the sub steps are available
         self.register_sub_step_classes(
             (TabulateVariantsStepPart, DeconstructSigsStepPart, LinkOutStepPart)
@@ -251,46 +264,26 @@ class SomaticVariantSignaturesWorkflow(BaseStep):
     @listify
     def get_result_files(self):
         """Return list of result files for workflow"""
-        config = self.w_config.step_config["somatic_variant_signatures"]
+        config = self.config
         name_pattern = "{mapper}.{caller}"
-        if config.is_filtered:
-            if len(config.filters) > 0:
-                name_pattern += ".{anno_caller}.dkfz_bias_filter.eb_filter"
-            else:
-                name_pattern += ".{anno_caller}.filtered"
-        name_pattern += ".deconstruct_sigs.{tumor_library.name}"
-        if config.is_filtered and len(config.filters) > 0:
-            name_pattern += ".{filter}.{region}"
+        if config.has_annotation:
+            name_pattern += ".{anno_caller}"
+        if config.filtration_schema == FiltrationSchema.list:
+            name_pattern += ".filtered.deconstruct_sigs.{tumor_library.name}"
+        elif config.filtration_schema == FiltrationSchema.sets:
+            name_pattern += ".dkfz_bias_filter.eb_filter.deconstruct_sigs.{tumor_library.name}.{filter}.{region}"
+        else:
+            name_pattern += ".deconstruct_sigs.{tumor_library.name}"
 
-        mappers = set(config.tools_ngs_mapping) & set(
-            self.w_config.step_config["ngs_mapping"].tools.dna
-        )
-        assert len(mappers) > 0, "No valid mapper"
-        callers = set(config.tools_somatic_variant_calling) & set(SOMATIC_VARIANT_CALLERS_MATCHED)
-        assert len(callers) > 0, "No valid somatic variant caller"
+        anno_callers = config.tools_somatic_variant_annotation if config.has_annotation else []
 
-        anno_callers = []
-        filters = []
-        regions = []
-        if config.is_filtered:
-            anno_callers = set(config.tools_somatic_variant_annotation) & set(ANNOTATION_TOOLS)
-            assert len(anno_callers) > 0, "No valid somatic variant annotation tool"
-            if len(config.filters) > 0:
-                filters = list(
-                    self.w_config.step_config["somatic_variant_filtration"].filter_sets.keys()
-                )
-                filters.append("no_filter")
-                filters = set(filters) & set(config.filters)
-                regions = list(
-                    self.w_config.step_config["somatic_variant_filtration"].exon_lists.keys()
-                )
-                regions.append("genome_wide")
-                regions = set(regions) & set(config.filtered_regions)
+        filters = config.filter_sets if config.filtration_schema == FiltrationSchema.sets else []
+        regions = config.exon_lists if config.filtration_schema == FiltrationSchema.sets else []
 
         yield from self._yield_result_files_matched(
             os.path.join("output", name_pattern, "out", name_pattern + ".tsv"),
-            mapper=mappers,
-            caller=callers,
+            mapper=config.tools_ngs_mapping,
+            caller=config.tools_somatic_variant_calling,
             anno_caller=anno_callers,
             filter=filters,
             region=regions,
@@ -319,9 +312,9 @@ class SomaticVariantSignaturesWorkflow(BaseStep):
                 )
 
     def check_config(self):
-        if self.config.is_filtered:
+        if self.config.filtration_schema != FiltrationSchema.unfiltered:
             self.ensure_w_config(
                 ("step_config", "somatic_variant_filtration"),
-                "When is_filtered is set to True, "
+                "When the filtration schema is not 'unfiltered', "
                 "the somatic_variant_filtration step must be configured",
             )

--- a/snappy_pipeline/workflows/somatic_variant_signatures/model.py
+++ b/snappy_pipeline/workflows/somatic_variant_signatures/model.py
@@ -1,3 +1,5 @@
+import enum
+
 from typing import Annotated
 
 from pydantic import Field
@@ -5,9 +7,20 @@ from pydantic import Field
 from snappy_pipeline.models import SnappyStepModel
 
 
-class SomaticVariantSignatures(SnappyStepModel):
-    is_filtered: bool = False
+class FiltrationSchema(enum.StrEnum):
+    unfiltered = "unfiltered"
+    list = "list"
+    sets = "sets"
 
+
+class FilterSet(enum.StrEnum):
+    NO_FILTER = "no_filter"
+    DKFZ_ONLY = "dkfz_only"
+    DKFZ_AND_EBFILTER = "dkfz_and_ebfilter"
+    DKFZ_AND_EBFILTER_AND_OXOG = "dkfz_and_ebfilter_and_oxog"
+
+
+class SomaticVariantSignatures(SnappyStepModel):
     path_somatic_variant: Annotated[str, Field(examples=["../somatic_variant_calling"])]
 
     tools_ngs_mapping: list[str] = []
@@ -19,11 +32,31 @@ class SomaticVariantSignatures(SnappyStepModel):
     tools_somatic_variant_annotation: list[str] = []
     """default to those configured for somatic_variant_annotation"""
 
-    filters: list[str] = []
+    has_annotation: bool = False
+    """Needed for building filenames only"""
+
+    filtration_schema: FiltrationSchema = FiltrationSchema.list
+    """Method of variant filtration (if any)"""
+
+    filter_before_annotation: bool = False
+    """Flag if filtration has been done before annotation"""
+
+    filter_sets: Annotated[
+        list[FilterSet], Field(None, deprecated="use `filter_list` instead")
+    ] = []
     """
-    When using variants after the somatic_variant_filtration step,
-    use "no_filter", "dkfz_only", "dkfz_and_ebfilter" or "dkfz_and_ebfilter_and_oxog"
+    DEPRECATED: use `filter_list instead`.
+    Set it to an empty value when using annotated variants without filtration.
     """
 
-    filtered_regions: list[str] = []
-    """When using variants after the somatic_variant_filtration step, use "genome_wide" or """ ""
+    exon_lists: Annotated[
+        list[str],
+        Field(
+            "genome_wide",
+            deprecated="Works together with filter_set, ignored when `filter_list` is selected",
+        ),
+    ] = []
+    """
+    DEPRECATED.
+    Works together with filter_set, ignored when "filter_list" is selected
+    """

--- a/snappy_pipeline/workflows/tumor_mutational_burden/model.py
+++ b/snappy_pipeline/workflows/tumor_mutational_burden/model.py
@@ -1,3 +1,5 @@
+import enum
+
 from typing import Annotated
 
 from pydantic import Field
@@ -5,11 +7,22 @@ from pydantic import Field
 from snappy_pipeline.models import SnappyStepModel
 
 
-class TumorMutationalBurden(SnappyStepModel):
-    has_annotation: bool
-    """TMB needs to know whether the vcf is annotated or not"""
+class FiltrationSchema(enum.StrEnum):
+    unfiltered = "unfiltered"
+    list = "list"
+    sets = "sets"
 
-    is_filtered: bool
+
+class FilterSet(enum.StrEnum):
+    NO_FILTER = "no_filter"
+    DKFZ_ONLY = "dkfz_only"
+    DKFZ_AND_EBFILTER = "dkfz_and_ebfilter"
+    DKFZ_AND_EBFILTER_AND_OXOG = "dkfz_and_ebfilter_and_oxog"
+
+
+class TumorMutationalBurden(SnappyStepModel):
+    has_annotation: bool = False
+    """Needed for building filenames only"""
 
     path_somatic_variant: Annotated[
         str, Field(examples=["../somatic_variant_annotation", "../somatic_variant_calling"])
@@ -25,14 +38,31 @@ class TumorMutationalBurden(SnappyStepModel):
     tools_somatic_variant_annotation: list[str] = []
     """default to those configured for somatic_variant_annotation"""
 
-    filters: list[str] = []
+    filtration_schema: FiltrationSchema = FiltrationSchema.list
+    """Method of variant filtration (if any)"""
+
+    filter_before_annotation: bool = False
+    """Flag if filtration has been done before annotation"""
+
+    filter_sets: Annotated[
+        list[FilterSet], Field(None, deprecated="use `filter_list` instead")
+    ] = []
     """
-    When using variants after the somatic_variant_filtration step,
-    use "no_filter", "dkfz_only", "dkfz_and_ebfilter" or "dkfz_and_ebfilter_and_oxog"
+    DEPRECATED: use `filter_list instead`.
+    Set it to an empty value when using annotated variants without filtration.
     """
 
-    filtered_regions: list[str] = []
-    """When using variants after the somatic_variant_filtration step, use "genome_wide" or "" """
+    exon_lists: Annotated[
+        list[str],
+        Field(
+            "genome_wide",
+            deprecated="Works together with filter_set, ignored when `filter_list` is selected",
+        ),
+    ] = []
+    """
+    DEPRECATED.
+    Works together with filter_set, ignored when "filter_list" is selected
+    """
 
     target_regions: str
     """Path to target_regions file (bed format)"""

--- a/tests/snappy_pipeline/workflows/test_tumor_mutational_burden.py
+++ b/tests/snappy_pipeline/workflows/test_tumor_mutational_burden.py
@@ -46,7 +46,7 @@ def minimal_config():
               path_target_regions: /path/to/target/regions.bed
 
           somatic_variant_annotation:
-            path_somatic_variant_calling: ../somatic_variant_calling
+            path_somatic_variant: ../somatic_variant_calling
             tools: ["vep", "jannovar"]
             jannovar:
               path_jannovar_ser: /path/to/jannover.ser
@@ -66,10 +66,8 @@ def minimal_config():
 
           tumor_mutational_burden:
             path_somatic_variant: ../somatic_variant_filtration
-            tools_ngs_mapping: []
             has_annotation: True # REQUIRED
-            is_filtered: True
-            tools_somatic_variant_calling: []
+            filtration_schema: sets
             target_regions: /path/to/regions.bed
 
         data_sets:

--- a/tests/snappy_pipeline/workflows/test_workflows_cbioportal_export.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_cbioportal_export.py
@@ -40,6 +40,7 @@ def minimal_config():
             path_somatic_variant: /SOM_VAR_FILTRATION
             somatic_variant_calling_tool: mutect2
             somatic_variant_annotation_tool: "vep"
+            filtration_schema: sets
             filter_set: dkfz_only
             path_copy_number: /COPY_NUMBER
             copy_number_tool: cnvkit

--- a/tests/snappy_pipeline/workflows/test_workflows_somatic_variant_annotation.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_somatic_variant_annotation.py
@@ -44,7 +44,7 @@ def minimal_config():
             mutect: {}
 
           somatic_variant_annotation:
-            path_somatic_variant_calling: /path/to/somatic_variant_calling
+            path_somatic_variant: /path/to/somatic_variant_calling
             tools: ["jannovar", "vep"]
             jannovar:
               dbnsfp: {}
@@ -85,7 +85,7 @@ def somatic_variant_annotation_workflow(
     # can obtain paths from the function as if we really had a NGSMappingPipelineStep there
     dummy_workflow.globals = {
         "ngs_mapping": lambda x: "NGS_MAPPING/" + x,
-        "somatic_variant_calling": lambda x: "SOMATIC_VARIANT_CALLING/" + x,
+        "somatic_variant": lambda x: "SOMATIC_VARIANT_CALLING/" + x,
     }
     # Construct the workflow object
     return SomaticVariantAnnotationWorkflow(

--- a/tests/snappy_pipeline/workflows/test_workflows_somatic_variant_signatures.py
+++ b/tests/snappy_pipeline/workflows/test_workflows_somatic_variant_signatures.py
@@ -30,16 +30,29 @@ def minimal_config():
             bwa:
               path_index: /path/to/bwa/index.fasta
 
+          somatic_variant_calling:
+            tools: ['mutect']
+            mutect:
+              keep_tmpdir: onerror
+
+          somatic_variant_annotation:
+            tools: [vep]
+            tools_somatic_variant_calling: ['mutect']
+            path_somatic_variant: ../SOMATIC_VARIANT_CALLING
+            vep:
+              cache_dir: /path/to/vep/cache
+
           somatic_variant_filtration:
             tools_somatic_variant_calling: ['mutect']
+            filtration_schema: list
             filter_list:
               - dkfz: {}
 
           somatic_variant_signatures:
             path_somatic_variant: ../SOMATIC_VARIANT_FILTRATION
-            tools_somatic_variant_annotation: ['vep']
             tools_somatic_variant_calling: ['mutect']
-            is_filtered: True
+            has_annotation: True
+            filtration_schema: list
 
         data_sets:
           first_batch:
@@ -114,7 +127,10 @@ def test_tabulate_vcf_step_part_get_output_files(somatic_variant_signatures_work
 
 def test_tabulate_vcf_step_part_get_log_file(somatic_variant_signatures_workflow):
     """Tests TabulateVariantsStepPart.get_log_file()"""
-    expected = "work/{mapper}.{var_caller}.{anno_caller}.filtered.tabulate_vcf.{tumor_library}/log/snakemake.tabulate_vcf.log"
+    expected = (
+        "work/{mapper}.{var_caller}.{anno_caller}.filtered.tabulate_vcf.{tumor_library}/log/"
+        "{mapper}.{var_caller}.{anno_caller}.filtered.tabulate_vcf.{tumor_library}.log"
+    )
     actual = somatic_variant_signatures_workflow.get_log_file("tabulate_vcf", "run")
     assert actual == expected
 
@@ -171,7 +187,7 @@ def test_deconstruct_sigs_step_part_get_log_file(somatic_variant_signatures_work
     """Tests DeconstructSigsStepPart.get_log_file()"""
     expected = (
         "work/{mapper}.{var_caller}.{anno_caller}.filtered.deconstruct_sigs.{tumor_library}/log/"
-        "snakemake.deconstruct_sigs.log"
+        "{mapper}.{var_caller}.{anno_caller}.filtered.deconstruct_sigs.{tumor_library}.log"
     )
     actual = somatic_variant_signatures_workflow.get_log_file("deconstruct_sigs", "run")
     assert actual == expected


### PR DESCRIPTION
Support for:
- annotation before or after filtration
- cbioportal import with or without filtration (annotation is mandatory)
- `tumor_mutational_burden` & `somatic_variant_signatures` can take their input from `somatic_variant_calling`, `somatic_variant_annotation` or `somatic_variant_filtration`

**UNTESTED - Manuela please test!!**

## Changes in config

### Annotation before filtration

```
somatic_variant_annotation:
  tools: [vep]
  path_somatic_variant: ../somatic_variant_calling
  filtration_schema: unfiltered
  vep:
    cache_dir: /path/to/cache_dir

somatic_variant_filtration:
  path_somatic_variant: ../somatic_variant_annotation
  has_annotation: true
  filtration_schema: list
  filter_list:
  ...

cbioportal_export:
  path_somatic_variant: ../somatic_variant_filtration
  filtration_schema: list
  filter_before_annotation: false
  ...
```

### Filtration before annotation

```
somatic_variant_filtration:
  path_somatic_variant: ../somatic_variant_calling
  has_annotation: false
  filtration_schema: list
  filter_list:
  ...

somatic_variant_annotation:
  tools: [vep]
  path_somatic_variant: ../somatic_variant_filtration
  filtration_schema: list
  vep:
    cache_dir: /path/to/cache_dir

cbioportal_export:
  path_somatic_variant: ../somatic_variant_annotation
  filtration_schema: list
  filter_before_annotation: true
  ...
```

### No filtration

```
somatic_variant_annotation:
  tools: [vep]
  path_somatic_variant: ../somatic_variant_calling
  filtration_schema: unfiltered
  vep:
    cache_dir: /path/to/cache_dir

cbioportal_export:
  path_somatic_variant: ../somatic_variant_annotation
  filtration_schema: unfiltered
  ...
```
