### PR TITLE
fix: missing f string prefix in arriba wrapper 

### DIFF
--- a/snappy_wrappers/wrappers/arriba/run/wrapper.py
+++ b/snappy_wrappers/wrappers/arriba/run/wrapper.py
@@ -24,7 +24,7 @@ reads_right = (
 
 trim_adapters = args["trim_adapters"]
 num_threads_trimming = args["num_threads_trimming"]
-trim_cmd = "trimadap-mt -p {num_threads_trimming}" if trim_adapters else "zcat"
+trim_cmd = f"trimadap-mt -p {num_threads_trimming}" if trim_adapters else "zcat"
 
 num_threads = args["num_threads"]
 arriba_index = args["path_index"]


### PR DESCRIPTION

##Bug
When running the somatic_gene_fusion_calling step with arriba and "trim_adapters: true", the pipeline fails with ERROR: failed to read SAM header. 

##Cause
In 'snappy_wrappers/wrappers/arriba/run/wrapper.py', 'trim_cmd' was built as a plain string instead of an f-string. Because it's not an f-string, `{num_threads_trimming}` was never substituted with the actual value.

##Fix
Add the missing 'f' prefix